### PR TITLE
Fix the build

### DIFF
--- a/src/frontend/main.qml
+++ b/src/frontend/main.qml
@@ -18,6 +18,10 @@
 import QtQuick 2.8
 import QtQuick.Window 2.2
 
+// FIXME: without this include, QtGamepad is
+// not included in the static build... Qt bug?
+import QtGamepad 1.0
+
 
 Window {
     id: appWindow


### PR DESCRIPTION
Something went wrong™ and now the automatic build fails to launch with a missing QtGamepad module error.