### PR TITLE
Add basic system informations to the API

### DIFF
--- a/src/backend/Api.h
+++ b/src/backend/Api.h
@@ -23,6 +23,7 @@
 #include "types/Meta.h"
 #include "types/Settings.h"
 #include "types/System.h"
+#include "types/SysInfo.h"
 #include "types/CollectionList.h"
 
 #include <QFutureWatcher>
@@ -43,6 +44,7 @@ class ApiObject : public QObject {
     Q_PROPERTY(Types::Meta* meta READ meta CONSTANT)
     Q_PROPERTY(Types::Settings* settings READ settings CONSTANT)
     Q_PROPERTY(Types::System* system READ system CONSTANT)
+    Q_PROPERTY(Types::SystemInfo* sysinfo READ sysinfo CONSTANT)
     Q_PROPERTY(Types::CollectionList* collectionList READ collectionList CONSTANT)
 
     // shortcuts
@@ -68,6 +70,7 @@ public:
     Types::Meta* meta() { return &m_meta; }
     Types::Settings* settings() { return &m_settings; }
     Types::System* system() { return &m_system; }
+    Types::SystemInfo* sysinfo() { return &m_sysinfo; }
     Types::CollectionList* collectionList() { return &m_collections; }
 
     // shortcuts
@@ -109,6 +112,7 @@ private slots:
 private:
     Types::Meta m_meta;
     Types::System m_system;
+    Types::SystemInfo m_sysinfo;
     Types::Settings m_settings;
     Types::Filters m_filters;
     Types::CollectionList m_collections;

--- a/src/backend/types/SysInfo.cpp
+++ b/src/backend/types/SysInfo.cpp
@@ -1,0 +1,43 @@
+// Pegasus Frontend
+// Copyright (C) 2018  Mátyás Mustoha
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "SysInfo.h"
+
+#include <QSysInfo>
+
+
+namespace Types {
+
+SystemInfo::SystemInfo(QObject* parent)
+    : QObject(parent)
+{
+}
+
+QString SystemInfo::arch() const
+{
+    return QSysInfo::currentCpuArchitecture();
+}
+QString SystemInfo::kernel() const
+{
+    return QSysInfo::kernelType();
+}
+QString SystemInfo::product() const
+{
+    return QSysInfo::productType();
+}
+
+} // namespace Types

--- a/src/backend/types/SysInfo.h
+++ b/src/backend/types/SysInfo.h
@@ -1,0 +1,40 @@
+// Pegasus Frontend
+// Copyright (C) 2018  Mátyás Mustoha
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+#pragma once
+
+#include <QObject>
+
+
+namespace Types {
+
+class SystemInfo : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(QString arch READ arch CONSTANT)
+    Q_PROPERTY(QString kernel READ arch CONSTANT)
+    Q_PROPERTY(QString product READ product CONSTANT)
+
+public:
+    explicit SystemInfo(QObject* parent = nullptr);
+
+    QString arch() const;
+    QString kernel() const;
+    QString product() const;
+};
+
+} // namespace Types

--- a/src/backend/types/types.pri
+++ b/src/backend/types/types.pri
@@ -12,6 +12,7 @@ HEADERS += \
     types/System.h \
     types/Theme.h \
     types/ThemeList.h \
+    types/SysInfo.h \
 
 SOURCES += \
     types/Collection.cpp \
@@ -27,3 +28,4 @@ SOURCES += \
     types/System.cpp \
     types/Theme.cpp \
     types/ThemeList.cpp \
+    types/SysInfo.cpp \


### PR DESCRIPTION
Some very basic system information. It's not enough for writing a system information panel, but enough for a basic platform check in themes, and that's pretty much what it's for. A global system info screen could be done later if there's a need.

Resolves #38.