### PR TITLE
Revert "The grid in the default theme now wraps vertically"

### DIFF
--- a/src/themes/pegasus-grid/layer_grid/GameGrid.qml
+++ b/src/themes/pegasus-grid/layer_grid/GameGrid.qml
@@ -32,8 +32,7 @@ FocusScope {
     signal nextPlatformRequested
     signal prevPlatformRequested
 
-    // NOTE: apparently keyNavigationWraps eats the input... QTBUG?
-    function onKeyPress(event) {
+    Keys.onPressed: {
         if (event.isAutoRepeat)
             return;
 
@@ -117,10 +116,6 @@ FocusScope {
 
 
         Keys.onPressed: {
-            root.onKeyPress(event);
-            if (event.accepted)
-                return;
-
             if (event.key === Qt.Key_PageUp || event.key === Qt.Key_PageDown) {
                 var rows_to_skip = Math.max(1, Math.round(grid.height / cellHeight));
                 var games_to_skip = rows_to_skip * columnCount;
@@ -145,7 +140,6 @@ FocusScope {
         }
 
         highlightMoveDuration: 0
-        keyNavigationWraps: true
 
         delegate: GameGridItem {
             width: GridView.view.cellWidth


### PR DESCRIPTION
This reverts commit 698d319258bb7aab6b11ca772ba340e56920a0d2.
This fixes the unresponsive Esc key. Also see QTBUG-69766.