### PR TITLE
Fix an ES2 asset searching bug

### DIFF
--- a/src/backend/providers/ProviderManager.cpp
+++ b/src/backend/providers/ProviderManager.cpp
@@ -45,14 +45,20 @@ namespace {
 void remove_empty_collections(HashMap<QString, modeldata::Collection>& collections,
                               HashMap<QString, std::vector<QString>>& collection_childs)
 {
-    auto it = collections.begin();
-    while (it != collections.end()) {
-        if (collection_childs[it->second.name()].empty()) {
-            qWarning().noquote() << tr_log("No games found for collection '%1', ignored").arg(it->second.name());
-            it = collections.erase(it);
+    std::vector<QString> empty_colls;
+
+    for (const auto& coll_entry : collections) {
+        const auto it = collection_childs.find(coll_entry.first);
+        if (it != collection_childs.cend() && collection_childs.at(it->first).size() > 0)
             continue;
-        }
-        ++it;
+
+        empty_colls.push_back(coll_entry.first);
+    }
+
+    for (const QString& coll : empty_colls) {
+        qWarning().noquote() << tr_log("No games found for collection '%1', ignored").arg(coll);
+        collections.erase(coll);
+        collection_childs.erase(coll);
     }
 }
 

--- a/src/backend/providers/es2/Es2Metadata.cpp
+++ b/src/backend/providers/es2/Es2Metadata.cpp
@@ -225,18 +225,25 @@ MetadataParser::MetadataParser(QObject* parent)
 
 void MetadataParser::enhance(HashMap<QString, modeldata::Game>& games,
                              const HashMap<QString, modeldata::Collection>& collections,
-                             const HashMap<QString, std::vector<QString>>&)
+                             const HashMap<QString, std::vector<QString>>& collection_childs)
 {
     const QString imgdir_base = paths::homePath()
                               % QStringLiteral("/.emulationstation/downloaded_images/");
     // shortpath: dir name + extensionless filename
     HashMap<QString, modeldata::Game* const> games_by_shortpath;
     games_by_shortpath.reserve(games.size());
-    for (auto& pair : games) {
-        const QString shortpath = pair.second.fileinfo().dir().dirName()
-                                % '/'
-                                % pair.second.fileinfo().completeBaseName();
-        games_by_shortpath.emplace(shortpath, &pair.second);
+    for (const auto& coll_titles_pair : collection_childs) {
+        Q_ASSERT(collections.count(coll_titles_pair.first));
+        const QString coll_shortname = collections.at(coll_titles_pair.first).shortName();
+
+        for (const auto& title : coll_titles_pair.second) {
+            Q_ASSERT(games.count(title));
+            modeldata::Game* const game = &games.at(title);
+
+            const QString gamefile = game->fileinfo().completeBaseName();
+            const QString shortpath = coll_shortname % '/' % gamefile;
+            games_by_shortpath.emplace(shortpath, game);
+        }
     }
 
 


### PR DESCRIPTION
It was assumed that the rom directory has the same name as the
collection short name.