### PR TITLE
Manually close the logs on exit

### DIFF
--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -18,6 +18,7 @@
 #include "Backend.h"
 
 #include "LocaleUtils.h"
+#include "Log.h"
 #include "ScriptRunner.h"
 #include "platform/PowerCommands.h"
 
@@ -43,6 +44,7 @@ void on_app_close(AppCloseType type)
     }
 
     qInfo().noquote() << tr_log("Closing Pegasus, goodbye!");
+    Log::close();
 
     QCoreApplication::quit();
     switch (type) {

--- a/src/backend/Log.cpp
+++ b/src/backend/Log.cpp
@@ -156,6 +156,11 @@ void Log::init()
     qInstallMessageHandler(on_qt_message);
 }
 
+void Log::close()
+{
+    m_sinks.clear();
+}
+
 #define FORALLSINK_CALLER(method) \
     void Log::method(const QString& message) \
     { \

--- a/src/backend/Log.h
+++ b/src/backend/Log.h
@@ -42,6 +42,7 @@ public:
     NO_COPY_NO_MOVE(Log)
 
     static void init();
+    static void close();
 
     static void info(const QString& message);
     static void warning(const QString& message);


### PR DESCRIPTION
This fixes a Qt bug where the global text codec is already destroyed
when QTextStream tries to flush its buffer on close. It also makes
sure that the logs are saved and flushed before shutdown/reboot.

Fixes #349.