### PR TITLE
Parameters for external scripts

### DIFF
--- a/src/backend/ProcessLauncher.cpp
+++ b/src/backend/ProcessLauncher.cpp
@@ -152,7 +152,7 @@ void ProcessLauncher::onLaunchRequested(const model::GameFile* q_gamefile)
     workdir = helpers::abs_workdir(workdir, game.relative_basedir, default_workdir);
 
 
-    beforeRun();
+    beforeRun(gamefile.fileinfo.absoluteFilePath());
     runProcess(command, args, workdir);
 }
 
@@ -234,10 +234,10 @@ void ProcessLauncher::onProcessFinished(int exitcode, QProcess::ExitStatus exits
     afterRun();
 }
 
-void ProcessLauncher::beforeRun()
+void ProcessLauncher::beforeRun(const QString& game_path)
 {
     TerminalKbd::enable();
-    ScriptRunner::run(ScriptEvent::PROCESS_STARTED);
+    ScriptRunner::run(ScriptEvent::PROCESS_STARTED, { game_path });
 }
 
 void ProcessLauncher::afterRun()

--- a/src/backend/ProcessLauncher.h
+++ b/src/backend/ProcessLauncher.h
@@ -58,6 +58,6 @@ private:
 
     void runProcess(const QString&, const QStringList&, const QString&);
 
-    void beforeRun();
+    void beforeRun(const QString&);
     void afterRun();
 };

--- a/src/backend/ScriptRunner.cpp
+++ b/src/backend/ScriptRunner.cpp
@@ -57,7 +57,7 @@ std::vector<QString> find_scripts_in(const QString& dirname)
     return all_scripts;
 }
 
-void execute_all(const std::vector<QString>& paths)
+void execute_all(const std::vector<QString>& paths, const QStringList& args)
 {
     Q_ASSERT(!paths.empty());
 
@@ -68,13 +68,18 @@ void execute_all(const std::vector<QString>& paths)
             .arg(i + 1, num_field_width)
             .arg(paths.size())
             .arg(paths[i]);
-        QProcess::execute(paths[i]);
+        QProcess::execute(paths[i], args);
     }
 }
 } // namespace
 
 
 void ScriptRunner::run(ScriptEvent event)
+{
+    run(event, {});
+}
+
+void ScriptRunner::run(ScriptEvent event, const QStringList& args)
 {
     static const HashMap<ScriptEvent, QString, EnumHash> SCRIPT_DIRS {
         { ScriptEvent::QUIT, QStringLiteral("quit") },
@@ -96,5 +101,5 @@ void ScriptRunner::run(ScriptEvent event)
         return;
 
     qInfo().noquote() << tr_log("Running `%1` scripts...").arg(dirname);
-    execute_all(scripts);
+    execute_all(scripts, args);
 }

--- a/src/backend/ScriptRunner.h
+++ b/src/backend/ScriptRunner.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+class QStringList;
+
 
 enum class ScriptEvent : unsigned char {
     QUIT,
@@ -34,4 +36,5 @@ enum class ScriptEvent : unsigned char {
 class ScriptRunner {
 public:
     static void run(ScriptEvent);
+    static void run(ScriptEvent, const QStringList&);
 };


### PR DESCRIPTION
Added an overridden function for `ScriptProcess::run` to allow passing a `const QStringList&` to containing parameters relevant to each ScriptEvent, e.g. the path of the process and the file name for a `ScriptEvent::PROCESS_STARTED` / `game-start` event.