### PR TITLE
Fix favorites for Steam games in LaunchBox

### DIFF
--- a/src/backend/model/gaming/GameFile.cpp
+++ b/src/backend/model/gaming/GameFile.cpp
@@ -29,24 +29,19 @@ QString pretty_filename(const QFileInfo& fi)
 }
 
 
-GameFileData::GameFileData(QFileInfo fi)
-    : fileinfo(std::move(fi))
+GameFileData::GameFileData(QString path)
+    : path(path)
+    , fileinfo(path)
     , name(pretty_filename(fileinfo))
-{}
-
-GameFileData::GameFileData(QFileInfo fi, QString new_name)
-    : fileinfo(std::move(fi))
-    , name(std::move(new_name))
 {}
 
 bool GameFileData::operator==(const GameFileData& other) const {
     return fileinfo == other.fileinfo;
 }
 
-
-GameFile::GameFile(QFileInfo finfo, model::Game& parent)
+GameFile::GameFile(QString path, model::Game &parent)
     : QObject(&parent)
-    , m_data(std::move(finfo))
+    , m_data(path)
 {}
 
 model::Game* GameFile::parentGame() const

--- a/src/backend/model/gaming/GameFile.h
+++ b/src/backend/model/gaming/GameFile.h
@@ -31,9 +31,9 @@ QString pretty_filename(const QFileInfo& fi);
 
 
 struct GameFileData {
-    explicit GameFileData(QFileInfo);
-    explicit GameFileData(QFileInfo, QString);
+    explicit GameFileData(QString);
 
+    const QString path;
     const QFileInfo fileinfo;
     QString name;
 
@@ -73,7 +73,7 @@ public:
     const QFileInfo& fileinfo() const { return m_data.fileinfo; }
 
 public:
-    explicit GameFile(QFileInfo, model::Game&);
+    explicit GameFile(QString, model::Game&);
 
     model::Game* parentGame() const;
 

--- a/tests/backend/model/game/test_Game.cpp
+++ b/tests/backend/model/game/test_Game.cpp
@@ -85,8 +85,8 @@ void test_Game::files()
 {
     model::Game game("test");
     game.setFiles({
-        new model::GameFile(QFileInfo("test1"), game),
-        new model::GameFile(QFileInfo("test2"), game),
+        new model::GameFile("test1", game),
+        new model::GameFile("test2", game),
     });
 
     QCOMPARE(game.filesConst().count(), 2);
@@ -97,7 +97,7 @@ void test_Game::files()
 void test_Game::launchSingle()
 {
     model::Game game("test");
-    game.setFiles({ new model::GameFile(QFileInfo("test"), game) });
+    game.setFiles({ new model::GameFile("test", game) });
 
     QSignalSpy spy_launch(game.filesConst().first(), &model::GameFile::launchRequested);
     QVERIFY(spy_launch.isValid());
@@ -110,8 +110,8 @@ void test_Game::launchMulti()
 {
     model::Game game("test");
     game.setFiles({
-        new model::GameFile(QFileInfo("test1"), game),
-        new model::GameFile(QFileInfo("test2"), game),
+        new model::GameFile("test1", game),
+        new model::GameFile("test2", game),
     });
 
     QSignalSpy spy_launch(&game, &model::Game::launchFileSelectorRequested);

--- a/tests/backend/providers/favorites/test_FavoriteDB.cpp
+++ b/tests/backend/providers/favorites/test_FavoriteDB.cpp
@@ -37,6 +37,9 @@ void create_dummy_data(providers::SearchContext& sctx)
 
     model::Game& game_c = *sctx.create_game_for(collection_b);
     sctx.game_add_filepath(game_c, QStringLiteral(":/x/y/z/coll2dummy1"));
+
+    model::Game& game_d = *sctx.create_game_for(collection_b);
+    sctx.game_add_uri(game_d, QStringLiteral("steam:1337"));
 }
 } // namespace
 
@@ -57,6 +60,7 @@ void test_FavoriteDB::write()
     create_dummy_data(sctx);
     sctx.game_by_filepath(QStringLiteral(":/coll1dummy2"))->setFavorite(true);
     sctx.game_by_filepath(QStringLiteral(":/x/y/z/coll2dummy1"))->setFavorite(true);
+    sctx.game_by_uri(QStringLiteral("steam:1337"))->setFavorite(true);
     const auto [collections, games] = sctx.finalize(this->thread());
 
     QTemporaryFile tmp_file;
@@ -94,10 +98,10 @@ void test_FavoriteDB::write()
     }
     QFile::remove(db_path);
 
-    QCOMPARE(found_items.count(), 2);
+    QCOMPARE(found_items.count(), 3);
     QVERIFY(found_items.contains(":/coll1dummy2"));
     QVERIFY(found_items.contains(":/x/y/z/coll2dummy1"));
-
+    QVERIFY(found_items.contains("steam:1337"));
 }
 
 void test_FavoriteDB::rewrite_empty()
@@ -156,6 +160,7 @@ void test_FavoriteDB::read()
         tmp_stream << QStringLiteral(":/x/y/z/coll2dummy1") << endl;
         tmp_stream << QStringLiteral(":/coll1dummy2") << endl;
         tmp_stream << QStringLiteral(":/somethingfake") << endl;
+        tmp_stream << QStringLiteral("steam:1337") << endl;
     }
     const QString db_path = tmp_file.fileName();
     tmp_file.close();
@@ -164,9 +169,10 @@ void test_FavoriteDB::read()
     const auto [collections, games] = sctx.finalize(this->thread());
     QFile::remove(db_path);
 
-    QCOMPARE(games[0]->isFavorite(), false);
-    QCOMPARE(games[1]->isFavorite(), true);
+    QCOMPARE(games[0]->isFavorite(), true);
+    QCOMPARE(games[1]->isFavorite(), false);
     QCOMPARE(games[2]->isFavorite(), true);
+    QCOMPARE(games[3]->isFavorite(), true);
 }
 
 


### PR DESCRIPTION
This fixes issues with favoriting games where the path is a URI that does not refer to a file, eg `steam:1337`

See https://github.com/mmatyas/pegasus-frontend/issues/814