### PR TITLE
Launch Steam games imported from Launchbox correctly

### DIFF
--- a/src/backend/providers/steam/SteamProvider.cpp
+++ b/src/backend/providers/steam/SteamProvider.cpp
@@ -49,31 +49,6 @@ QString flatpak_data_dir() {
 }
 #endif // Q_OS_LINUX
 
-QString find_steam_call()
-{
-#ifdef Q_OS_WIN
-    QSettings reg_base(QStringLiteral("HKEY_CURRENT_USER\\Software\\Valve\\Steam"), QSettings::NativeFormat);
-    QString reg_value = reg_base.value(QLatin1String("SteamExe")).toString();
-    if (!reg_value.isEmpty())
-        return ::utils::escape_command(reg_value);
-#endif
-
-#ifdef Q_OS_LINUX
-    // Assume the Flatpak version exists if its data directory is present
-    const QString flatpak_data_dir = ::flatpak_data_dir();
-    if (QFileInfo::exists(flatpak_data_dir))
-        return ::flatpak_launch_cmd();
-#endif
-
-#ifdef Q_OS_MACOS
-    // it should be installed
-    return QStringLiteral("open -a Steam --args");
-#else
-    // it should be in the PATH
-    return QStringLiteral("steam");
-#endif
-}
-
 QString find_steam_datadir()
 {
     std::vector<QString> possible_dirs;
@@ -183,6 +158,31 @@ void fill_metadata_from_network(
 
 namespace providers {
 namespace steam {
+
+QString find_steam_call()
+{
+#ifdef Q_OS_WIN
+    QSettings reg_base(QStringLiteral("HKEY_CURRENT_USER\\Software\\Valve\\Steam"), QSettings::NativeFormat);
+    QString reg_value = reg_base.value(QLatin1String("SteamExe")).toString();
+    if (!reg_value.isEmpty())
+        return ::utils::escape_command(reg_value);
+#endif
+
+#ifdef Q_OS_LINUX
+    // Assume the Flatpak version exists if its data directory is present
+    const QString flatpak_data_dir = ::flatpak_data_dir();
+    if (QFileInfo::exists(flatpak_data_dir))
+        return ::flatpak_launch_cmd();
+#endif
+
+#ifdef Q_OS_MACOS
+    // it should be installed
+    return QStringLiteral("open -a Steam --args");
+#else
+    // it should be in the PATH
+    return QStringLiteral("steam");
+#endif
+}
 
 SteamProvider::SteamProvider(QObject* parent)
     : Provider(QLatin1String("steam"), QStringLiteral("Steam"), parent)

--- a/src/backend/providers/steam/SteamProvider.h
+++ b/src/backend/providers/steam/SteamProvider.h
@@ -23,6 +23,8 @@
 namespace providers {
 namespace steam {
 
+QString find_steam_call();
+
 class SteamProvider : public Provider {
     Q_OBJECT
 


### PR DESCRIPTION
Adds support for launching Steam games and Origin games that were imported via LaunchBox.

To do this we are exposing the `find_steam_call` method in `SteamProvider` so it can be shared with the LaunchBox provider

Not sure if that is the best way to do that