### PR TITLE
Fix launching apps on Android 11

### DIFF
--- a/src/backend/providers/android_apps/AndroidAppsProvider.cpp
+++ b/src/backend/providers/android_apps/AndroidAppsProvider.cpp
@@ -37,9 +37,6 @@ HashMap<QString, model::Game*> find_apps_for(model::Collection& collection, prov
     constexpr auto APPLIST_SIGNATURE = "()[Lorg/pegasus_frontend/android/App;";
     constexpr auto APP_NAME = "appName";
     constexpr auto APP_PACKAGE = "packageName";
-    constexpr auto APP_LAUNCH_ACT = "launchAction";
-    constexpr auto APP_LAUNCH_CPT = "launchComponent";
-
 
     HashMap<QString, model::Game*> app_game_map;
 
@@ -53,8 +50,6 @@ HashMap<QString, model::Game*> find_apps_for(model::Collection& collection, prov
 
         const QString appname = jni_app.callObjectMethod<jstring>(APP_NAME).toString();
         const QString package = jni_app.callObjectMethod<jstring>(APP_PACKAGE).toString();
-        const QString action = jni_app.callObjectMethod<jstring>(APP_LAUNCH_ACT).toString();
-        const QString component = jni_app.callObjectMethod<jstring>(APP_LAUNCH_CPT).toString();
 
         const QString game_uri = QStringLiteral("android:") + package;
         model::Game* game_ptr = sctx.game_by_uri(game_uri);
@@ -67,7 +62,7 @@ HashMap<QString, model::Game*> find_apps_for(model::Collection& collection, prov
         const QString icon_uri = QStringLiteral("image://androidicons/") + package;
         (*game_ptr)
             .setTitle(appname)
-            .setLaunchCmd(QStringLiteral("am start --user 0 -a %1 -n %2").arg(action, component))
+            .setLaunchCmd(package)
             .assetsMut()
             .add_uri(AssetType::BOX_FRONT, icon_uri)
             .add_uri(AssetType::UI_TILE, icon_uri);


### PR DESCRIPTION
This is a fix for https://github.com/mmatyas/pegasus-frontend/issues/766

Issue is `am` call is no longer allowed from device on Android 11.

Fix is to use the `startActivity` method to launch the apps rather than a shell command.  In order to make this change minimal we also launch a bogus process `pwd` (which is allowed on Android 11) so the process handling can proceed as normal.  This shouldn't change the functionality considering that the `am` call returned immediately anyways, but it is a bit of a hack.  

An alternative solution and slightly less hacky solution would be to have a separate process launcher for Android that doesn't use QProcess at all