### PR TITLE
Add support for building with Qt 6

### DIFF
--- a/pegasus.pro
+++ b/pegasus.pro
@@ -1,7 +1,7 @@
 REQ_QT_MAJOR = 5
 REQ_QT_MINOR = 12
 
-lessThan(QT_MAJOR_VERSION, $${REQ_QT_MAJOR}) | lessThan(QT_MINOR_VERSION, $${REQ_QT_MINOR}) {
+lessThan(QT_MAJOR_VERSION, $${REQ_QT_MAJOR}) | equals(QT_MAJOR_VERSION, $${REQ_QT_MAJOR}):lessThan(QT_MINOR_VERSION, $${REQ_QT_MINOR}) {
     message("Cannot build this project using Qt $$[QT_VERSION]")
     error("This project requires at least Qt $${REQ_QT_MAJOR}.$${REQ_QT_MINOR} or newer")
 }


### PR DESCRIPTION
Tried to build with Qt6 and was getting an error because my minor version was less than 12, even though the major version was greater than 5.