### PR TITLE
Add "--disable-menu-help" and "--bartop" to command-line arguments

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -145,6 +145,10 @@ backend::CliArgs handle_cli_args(QGuiApplication& app)
         QStringLiteral("disable-menu-settings"),
         CMDMSG("Hides the settings menu entry in the main menu"));
 
+    const QCommandLineOption arg_menu_help = add_cli_option(argparser,
+        QStringLiteral("disable-menu-help"),
+        CMDMSG("Hides the help menu entry and version number in the main menu"));
+
     const QCommandLineOption arg_menu_kiosk = add_cli_option(argparser,
         QStringLiteral("kiosk"),
         CMDMSG("Alias for:\n"
@@ -152,6 +156,14 @@ backend::CliArgs handle_cli_args(QGuiApplication& app)
                "--disable-menu-shutdown\n"
                "--disable-menu-appclose\n"
                "--disable-menu-settings"));
+
+    const QCommandLineOption arg_menu_bartop = add_cli_option(argparser,
+        QStringLiteral("bartop"),
+        CMDMSG("Alias for:\n"
+               "--disable-menu-settings\n"
+               "--disable-menu-help\n"
+               "--disable-menu-suspend\n"
+               "--disable-menu-appclose"));
 
     const QCommandLineOption arg_gamepad_autoconfig = add_cli_option(argparser,
         QStringLiteral("disable-gamepad-autoconfig"),
@@ -168,8 +180,9 @@ backend::CliArgs handle_cli_args(QGuiApplication& app)
     backend::CliArgs args;
     args.portable = argparser.isSet(arg_portable);
     args.silent = argparser.isSet(arg_silent);
-    args.enable_menu_appclose = !(argparser.isSet(arg_menu_kiosk) || argparser.isSet(arg_menu_appclose));
-    args.enable_menu_settings = !(argparser.isSet(arg_menu_kiosk) || argparser.isSet(arg_menu_settings));
+    args.enable_menu_appclose = !(argparser.isSet(arg_menu_kiosk) || argparser.isSet(arg_menu_bartop) || argparser.isSet(arg_menu_appclose));
+    args.enable_menu_settings = !(argparser.isSet(arg_menu_kiosk) || argparser.isSet(arg_menu_bartop) || argparser.isSet(arg_menu_settings));
+    args.enable_menu_help = !(argparser.isSet(arg_menu_bartop) || argparser.isSet(arg_menu_help));
     args.enable_gamepad_autoconfig = !argparser.isSet(arg_gamepad_autoconfig);
 #ifdef Q_OS_ANDROID
     args.enable_menu_shutdown = false;
@@ -181,7 +194,7 @@ backend::CliArgs handle_cli_args(QGuiApplication& app)
 #if defined(Q_OS_ANDROID) || defined(Q_OS_WINDOWS) || defined(Q_OS_MAC)
     args.enable_menu_suspend = false;
 #else
-    args.enable_menu_suspend = !(argparser.isSet(arg_menu_kiosk) || argparser.isSet(arg_menu_suspend));
+    args.enable_menu_suspend = !(argparser.isSet(arg_menu_kiosk) || argparser.isSet(arg_menu_bartop) || argparser.isSet(arg_menu_suspend));
 #endif
     return args;
 

--- a/src/backend/CliArgs.h
+++ b/src/backend/CliArgs.h
@@ -26,6 +26,7 @@ struct CliArgs {
     bool enable_menu_suspend = true;
     bool enable_menu_reboot = true;
     bool enable_menu_settings = true;
+    bool enable_menu_help = false;
     bool enable_gamepad_autoconfig = true;
 };
 } // namespace backend

--- a/src/backend/model/internal/Meta.cpp
+++ b/src/backend/model/internal/Meta.cpp
@@ -34,6 +34,7 @@ Meta::Meta(const backend::CliArgs& args, QObject* parent)
     , m_enable_menu_suspend(args.enable_menu_suspend)
     , m_enable_menu_appclose(args.enable_menu_appclose)
     , m_enable_menu_settings(args.enable_menu_settings)
+    , m_enable_menu_help(args.enable_menu_help)
     , m_loading(true)
     , m_loading_progress(0.f)
 {}

--- a/src/backend/model/internal/Meta.h
+++ b/src/backend/model/internal/Meta.h
@@ -41,6 +41,7 @@ class Meta : public QObject {
     Q_PROPERTY(bool allowSuspend MEMBER m_enable_menu_suspend CONSTANT)
     Q_PROPERTY(bool allowAppClose MEMBER m_enable_menu_appclose CONSTANT)
     Q_PROPERTY(bool allowSettings MEMBER m_enable_menu_settings CONSTANT)
+    Q_PROPERTY(bool allowHelp MEMBER m_enable_menu_help CONSTANT)
 
 public:
     explicit Meta(const backend::CliArgs& args, QObject* parent = nullptr);
@@ -77,6 +78,7 @@ private:
     const bool m_enable_menu_suspend;
     const bool m_enable_menu_appclose;
     const bool m_enable_menu_settings;
+    const bool m_enable_menu_help;
 
     bool m_loading;
     QString m_loading_stage;

--- a/src/frontend/MenuLayer.qml
+++ b/src/frontend/MenuLayer.qml
@@ -68,6 +68,9 @@ FocusScope {
             anchors.left: parent.left
             anchors.bottom: parent.bottom
             anchors.margins: vpx(10)
+            
+            enabled: api.internal.meta.allowHelp
+            visible: enabled
         }
 
         MouseArea {

--- a/src/frontend/menu/MainMenuPanel.qml
+++ b/src/frontend/menu/MainMenuPanel.qml
@@ -64,6 +64,13 @@ FocusScope {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: vpx(30)
 
+        Rectangle {
+            width: parent.width
+            height: 200
+            color: "#333"
+            z: 1000
+        }
+
         PrimaryMenuItem {
             id: mbSettings
             text: qsTr("Settings") + api.tr
@@ -86,6 +93,9 @@ FocusScope {
                 root.showHelpScreen();
             }
             selected: focus
+
+            enabled: api.internal.meta.allowHelp
+            visible: enabled
 
             KeyNavigation.down: scopeQuit
         }


### PR DESCRIPTION
Add command-line option to hide the Help menu and another option similar to kiosk mode.