### PR TITLE
Generate ContentUris that ppsspp accepts

### DIFF
--- a/src/app/platform/android/src/org/pegasus_frontend/android/LaunchFileProvider.java
+++ b/src/app/platform/android/src/org/pegasus_frontend/android/LaunchFileProvider.java
@@ -17,7 +17,67 @@
 
 package org.pegasus_frontend.android;
 
+import android.content.Context;
+import android.content.ContentValues;
 import androidx.core.content.FileProvider;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URLEncoder;
+import java.util.List;
 
+public class LaunchFileProvider extends FileProvider {
 
-public class LaunchFileProvider extends FileProvider {}
+    public static final String LAUNCHFILEPROVIDER_AUTHORITY = "org.pegasus_frontend.android.files";
+
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        throw new UnsupportedOperationException();
+    }
+
+    public String getType(Uri uri) {
+        return super.getType(convertToFileProviderUri(uri));
+    }
+
+    public static Uri getUriForFile(Context context, String authority, File file) {
+        return convertFromFileProviderUri(FileProvider.getUriForFile(context, authority, file));
+    }
+
+    public static Uri getUriForFile(Context context, String authority, File file, String displayName) {
+        return convertFromFileProviderUri(FileProvider.getUriForFile(context, authority, file, displayName));
+    }
+
+    public Uri insert(Uri uri, ContentValues values) {
+        throw new UnsupportedOperationException();
+    }
+
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        if (mode != "r") {
+            throw new IllegalArgumentException("Launch Files must be opened read-only");
+        }
+        return super.openFile(convertToFileProviderUri(uri), mode);
+    }
+
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        return super.query(uri, projection, selection, selectionArgs, sortOrder);
+    }
+
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        throw new UnsupportedOperationException();
+    }
+
+    private static Uri convertToFileProviderUri(Uri launchFileProviderUri) {
+        List<String> pathSegments = launchFileProviderUri.getPathSegments();
+        if (pathSegments.size() != 2) {
+            throw new IllegalArgumentException(
+                "Pegasus content uris must be in the form: content://org.pegasus_frontend.android.files/document/<url encoded path>");
+        }
+        return Uri.parse("content://" + LAUNCHFILEPROVIDER_AUTHORITY + Uri.decode(pathSegments.get(1)));
+    }
+
+    private static Uri convertFromFileProviderUri(Uri fileProviderUri) {
+        String fp = Uri.encode(fileProviderUri.getPath());
+        return Uri.parse("content://" + LAUNCHFILEPROVIDER_AUTHORITY + "/document/" + fp);
+    }
+}

--- a/src/app/platform/android/src/org/pegasus_frontend/android/MainActivity.java
+++ b/src/app/platform/android/src/org/pegasus_frontend/android/MainActivity.java
@@ -231,9 +231,9 @@ public class MainActivity extends org.qtproject.qt5.android.bindings.QtActivity 
     }
 
     public static String toContentUri(String path) {
-        final Uri uri = FileProvider.getUriForFile(
+        final Uri uri = LaunchFileProvider.getUriForFile(
             m_context,
-            "org.pegasus_frontend.android.files",
+            LaunchFileProvider.LAUNCHFILEPROVIDER_AUTHORITY,
             new File(path));
         return uri.toString();
     }


### PR DESCRIPTION
PPSSPP expects ContentUris to be in the format:
content://<authority>/document/<other stuff>

So we urlencode the path from the content uri we get from FileProvider, and use that as the "other stuff" in the uri format above.
When we then recieve a request for that file, we can decode the uri and pass it on to FileProvider.