### PR TITLE
Reduce the number of file permission tests

### DIFF
--- a/src/backend/providers/pegasus_media/MediaProvider.cpp
+++ b/src/backend/providers/pegasus_media/MediaProvider.cpp
@@ -72,7 +72,7 @@ MediaProvider::MediaProvider(QObject* parent)
 
 Provider& MediaProvider::run(SearchContext& sctx)
 {
-    constexpr auto dir_filters = QDir::Files | QDir::Readable | QDir::NoDotAndDotDot;
+    constexpr auto dir_filters = QDir::Files | QDir::NoDotAndDotDot;
     constexpr auto dir_flags = QDirIterator::Subdirectories | QDirIterator::FollowSymlinks;
     constexpr int media_len = 6; // length of `/media`
 

--- a/src/backend/providers/pegasus_metadata/PegasusFilter.cpp
+++ b/src/backend/providers/pegasus_metadata/PegasusFilter.cpp
@@ -33,7 +33,7 @@ std::vector<QString> all_valid_direct_subdirs(const QString& filter_dir)
 {
     Q_ASSERT(!filter_dir.isEmpty());
 
-    constexpr auto subdir_filters = QDir::Dirs | QDir::Readable | QDir::NoDotAndDotDot;
+    constexpr auto subdir_filters = QDir::Dirs | QDir::NoDotAndDotDot;
     constexpr auto subdir_flags = QDirIterator::FollowSymlinks;
 
     std::vector<QString> result;
@@ -148,7 +148,7 @@ void apply_filter(FileFilter& filter, SearchContext& sctx)
     if (!needs_scan)
         return;
 
-    constexpr auto entry_filters_files = QDir::Files | QDir::Readable | QDir::NoDotAndDotDot;
+    constexpr auto entry_filters_files = QDir::Files | QDir::NoDotAndDotDot;
     constexpr auto entry_filters_all = QDir::Dirs | entry_filters_files;
     constexpr auto entry_flags = QDirIterator::FollowSymlinks | QDirIterator::Subdirectories;
     for (const QString& filter_dir : filter.directories) {

--- a/src/backend/providers/pegasus_metadata/PegasusProvider.cpp
+++ b/src/backend/providers/pegasus_metadata/PegasusProvider.cpp
@@ -39,7 +39,7 @@ bool is_metadata_file(const QString& filename)
 
 std::vector<QString> find_metafiles_in(const QString& dir_path)
 {
-    constexpr auto dir_filters = QDir::Files | QDir::Readable | QDir::NoDotAndDotDot;
+    constexpr auto dir_filters = QDir::Files | QDir::NoDotAndDotDot;
     constexpr auto dir_flags = QDirIterator::FollowSymlinks;
 
     std::vector<QString> result;
@@ -47,9 +47,10 @@ std::vector<QString> find_metafiles_in(const QString& dir_path)
     QDirIterator dir_it(dir_path, dir_filters, dir_flags);
     while (dir_it.hasNext()) {
         dir_it.next();
-        QString path = ::clean_abs_path(dir_it.fileInfo());
-        if (is_metadata_file(dir_it.fileName()))
+        if (is_metadata_file(dir_it.fileName())) {
+            QString path = ::clean_abs_path(dir_it.fileInfo());
             result.emplace_back(std::move(path));
+        }
     }
 
     return result;


### PR DESCRIPTION
Do not care about file permissions when looking for metadata and media
files or directories.