### PR TITLE
Add Epic Games provider

### DIFF
--- a/src/backend/AppSettings.cpp
+++ b/src/backend/AppSettings.cpp
@@ -52,6 +52,9 @@
 #ifdef WITH_COMPAT_PLAYNITE
   #include "providers/playnite/PlayniteProvider.h"
 #endif
+#ifdef WITH_COMPAT_EPICGAMES
+  #include "providers/epicgames/EpicGamesProvider.h"
+#endif
 
 #include <QFile>
 
@@ -125,6 +128,9 @@ std::vector<std::unique_ptr<providers::Provider>> create_providers()
 #endif
 #ifdef WITH_COMPAT_PLAYNITE
         MKENTRY(playnite::PlayniteProvider)
+#endif
+#ifdef WITH_COMPAT_EPICGAMES
+        MKENTRY(epicgames::EpicGamesProvider)
 #endif
 
         // Make sure these come last as they never add new games

--- a/src/backend/providers/CMakeLists.txt
+++ b/src/backend/providers/CMakeLists.txt
@@ -51,6 +51,7 @@ endfunction()
 
 
 add_subdirectory(android_apps)
+add_subdirectory(epicgames)
 add_subdirectory(es2)
 add_subdirectory(gog)
 add_subdirectory(launchbox)

--- a/src/backend/providers/epicgames/CMakeLists.txt
+++ b/src/backend/providers/epicgames/CMakeLists.txt
@@ -1,0 +1,12 @@
+pegasus_add_provider(
+    NAME "Epic Games"
+    CXXID EPICGAMES
+    SOURCES
+        EpicGamesGamelist.cpp
+        EpicGamesGamelist.h
+        EpicGamesProvider.cpp
+        EpicGamesProvider.h
+    USES_JSON_CACHE
+    PLATFORMS
+        WINDOWS
+)

--- a/src/backend/providers/epicgames/EpicGamesGamelist.cpp
+++ b/src/backend/providers/epicgames/EpicGamesGamelist.cpp
@@ -1,0 +1,127 @@
+// Pegasus Frontend
+// Copyright (C) 2017-2020  Mátyás Mustoha
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "EpicGamesGamelist.h"
+
+#include "Log.h"
+#include "model/gaming/Game.h"
+#include "providers/SearchContext.h"
+#include "utils/CommandTokenizer.h"
+
+#include <QDirIterator>
+#include <QStringBuilder>
+
+
+namespace providers {
+namespace epicgames {
+
+Gamelist::Gamelist(QString log_tag)
+    : m_log_tag(std::move(log_tag))
+    , m_name_filters { QStringLiteral("*.item") }
+    , m_rx_manifest_catalog_app_name(QStringLiteral(R""("MainGameAppName":\s+"([^"]+)")""))
+    , m_rx_manifest_title(QStringLiteral(R""("DisplayName":\s+"([^"]+)")""))
+{}
+
+std::tuple<QString, QString> Gamelist::read_manifest_file(const QString& manifest_path) const
+{
+    QFile manifest(manifest_path);
+    if (!manifest.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        Log::error(m_log_tag, LOGMSG("Could not open `%1`").arg(manifest_path));
+        return {};
+    }
+
+    QString catalog_app_name;
+    QString title;
+
+    QTextStream stream(&manifest);
+    while (!stream.atEnd() && (catalog_app_name.isEmpty() || title.isEmpty())) {
+        const QString line = stream.readLine();
+
+        const auto catalog_app_name_match = m_rx_manifest_catalog_app_name.match(line);
+        if (catalog_app_name_match.hasMatch()) {
+            catalog_app_name = catalog_app_name_match.captured(1);
+            continue;
+        }
+
+        const auto title_match = m_rx_manifest_title.match(line);
+        if (title_match.hasMatch()) {
+            title = title_match.captured(1);
+            continue;
+        }
+    }
+
+    return { catalog_app_name, title };
+}
+
+// TODO: Simplfy - seems Epic Games only has one manifest dir
+HashMap<QString, model::Game*> Gamelist::find_in(
+    const QString& epicgames_call,
+    const QString& dir_path,
+    model::Collection& collection,
+    SearchContext& sctx) const
+{
+    HashMap<QString, model::Game*> result;
+
+    constexpr auto dir_filters = QDir::Files | QDir::Readable | QDir::NoDotAndDotDot;
+    constexpr auto dir_flags = QDirIterator::FollowSymlinks;
+
+    QDirIterator dir_it(dir_path, m_name_filters, dir_filters, dir_flags);
+    while (dir_it.hasNext()) {
+        const QString manifest_path = dir_it.next();
+        const QFileInfo finfo = dir_it.fileInfo();
+
+        Log::info(m_log_tag, LOGMSG("Processing `%1`").arg(manifest_path));
+
+        // TODO: C++17
+        QString catalog_app_name;
+        QString title;
+        std::tie(catalog_app_name, title) = read_manifest_file(manifest_path);
+        if (catalog_app_name.isEmpty())
+            continue;
+        if (title.isEmpty())
+            title = QLatin1String("Codename ") + catalog_app_name;
+
+        const QString epicgames_uri = QLatin1String("epicgames:") % catalog_app_name;
+        model::Game* game_ptr = sctx.game_by_uri(epicgames_uri);
+        if (!game_ptr) {
+            game_ptr = sctx.create_game_for(collection);
+            sctx.game_add_uri(*game_ptr, epicgames_uri);
+        }
+        sctx.game_add_to(*game_ptr, collection);
+
+        const QString game_url = ::utils::escape_command(
+                QLatin1String(" com.epicgames.launcher://apps/") %
+                catalog_app_name %
+                QLatin1String("?action=launch&silent=true"));
+
+        const QString launch_cmd = epicgames_call % game_url;
+
+        Log::info(m_log_tag, LOGMSG("Setting launch cmd `%1`").arg(launch_cmd));
+
+        (*game_ptr)
+            .setTitle(title)
+            .setSortBy(title)
+            .setLaunchCmd(launch_cmd);
+
+        result.emplace(catalog_app_name, game_ptr);
+    }
+
+    return result;
+}
+
+} // namespace epicgames
+} // namespace providers

--- a/src/backend/providers/epicgames/EpicGamesGamelist.h
+++ b/src/backend/providers/epicgames/EpicGamesGamelist.h
@@ -1,0 +1,50 @@
+// Pegasus Frontend
+// Copyright (C) 2017-2020  Mátyás Mustoha
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+#pragma once
+
+#include "utils/HashMap.h"
+
+#include <QRegularExpression>
+#include <QStringList>
+
+namespace model { class Game; }
+namespace model { class Collection; }
+namespace providers { class SearchContext; }
+
+
+namespace providers {
+namespace epicgames {
+
+class Gamelist {
+public:
+    explicit Gamelist(QString);
+
+    HashMap<QString, model::Game*> find_in(const QString&, const QString&, model::Collection&, SearchContext&) const;
+
+private:
+    const QString m_log_tag;
+    const QStringList m_name_filters;
+    const std::vector<QLatin1String> m_ignored_manifests;
+    const QRegularExpression m_rx_manifest_catalog_app_name;
+    const QRegularExpression m_rx_manifest_title;
+
+    std::tuple<QString, QString> read_manifest_file(const QString&) const;
+};
+
+} // namespace epicgames
+} // namespace providers

--- a/src/backend/providers/epicgames/EpicGamesProvider.cpp
+++ b/src/backend/providers/epicgames/EpicGamesProvider.cpp
@@ -1,0 +1,98 @@
+// Pegasus Frontend
+// Copyright (C) 2017-2020  Mátyás Mustoha
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "EpicGamesProvider.h"
+
+#include "Log.h"
+#include "Paths.h"
+#include "providers/ProviderUtils.h"
+#include "providers/SearchContext.h"
+#include "providers/epicgames/EpicGamesGamelist.h"
+#include "utils/CommandTokenizer.h"
+#include "utils/StdHelpers.h"
+
+#include <QDir>
+#include <QSettings>
+#include <QStandardPaths>
+#include <QStringBuilder>
+#include <QTextStream>
+
+
+namespace {
+QString find_epicgames_datadir()
+{
+    std::vector<QString> possible_dirs;
+
+    // TODO: Add search for reg keys
+    /* const QSettings reg_base(QStringLiteral("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\TODO"), QSettings::NativeFormat); */
+    /* const QString reg_value = reg_base.value(QLatin1String("SteamPath")).toString(); */
+    /* if (!reg_value.isEmpty()) */
+    /*     possible_dirs.emplace_back(reg_value + QChar('/')); */
+
+    // TODO: Remove hardcoded strings if possible
+    possible_dirs.emplace_back(QLatin1String("C:\\ProgramData\\Epic\\EpicGamesLauncher\\Data\\Manifests"));
+
+    for (const QString& dir_path : possible_dirs) {
+        if (QFileInfo::exists(dir_path))
+            return dir_path;
+    }
+
+    return {};
+}
+
+QString find_epicgames_call()
+{
+    // TODO: Remove hardcoded strings if possible
+    return ::utils::escape_command(QLatin1String("C:\\Program Files (x86)\\Epic Games\\Launcher\\Portal\\Binaries\\Win64\\EpicGamesLauncher.exe"));
+}
+} // namespace
+
+
+namespace providers {
+namespace epicgames {
+
+EpicGamesProvider::EpicGamesProvider(QObject* parent)
+    : Provider(QLatin1String("epicgames"), QStringLiteral("Epic Games"), parent)
+{}
+
+Provider& EpicGamesProvider::run(SearchContext& sctx)
+{
+    const QString epicgamesdir_path = find_epicgames_datadir();
+    if (epicgamesdir_path.isEmpty()) {
+        Log::info(display_name(), LOGMSG("No installation found"));
+        return *this;
+    }
+
+    Log::info(display_name(), LOGMSG("Found Epic Games data at `%1`").arg(epicgamesdir_path));
+
+    model::Collection& collection = *sctx.get_or_create_collection(QStringLiteral("Epic Games"));
+
+    const Gamelist gamehelper(display_name());
+
+	const QString epicgames_call = find_epicgames_call();
+
+    HashMap<QString, model::Game*> appid_game_map = gamehelper.find_in(epicgames_call, epicgamesdir_path, collection, sctx);
+
+    Log::info(display_name(), LOGMSG("%1 games found").arg(QString::number(appid_game_map.size())));
+    if (appid_game_map.empty())
+        return *this;
+
+    return *this;
+}
+
+} // namespace epicgames
+} // namespace providers

--- a/src/backend/providers/epicgames/EpicGamesProvider.h
+++ b/src/backend/providers/epicgames/EpicGamesProvider.h
@@ -1,0 +1,36 @@
+// Pegasus Frontend
+// Copyright (C) 2017-2020  Mátyás Mustoha
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+#pragma once
+
+#include "providers/Provider.h"
+
+
+namespace providers {
+namespace epicgames {
+
+class EpicGamesProvider : public Provider {
+    Q_OBJECT
+
+public:
+    explicit EpicGamesProvider(QObject* parent = nullptr);
+
+    Provider& run(SearchContext&) final;
+};
+
+} // namespace epicgames
+} // namespace providers

--- a/src/backend/providers/epicgames/epicgames.pri
+++ b/src/backend/providers/epicgames/epicgames.pri
@@ -1,0 +1,12 @@
+ENABLED_COMPATS += EpicGames
+USES_JSON_CACHE = yes
+
+DEFINES *= WITH_COMPAT_EPICGAMES
+
+HEADERS += \
+    $$PWD/EpicGamesGamelist.h \
+    $$PWD/EpicGamesProvider.h \
+
+SOURCES += \
+    $$PWD/EpicGamesGamelist.cpp \
+    $$PWD/EpicGamesProvider.cpp \

--- a/src/backend/providers/providers.pri
+++ b/src/backend/providers/providers.pri
@@ -27,6 +27,7 @@ win32|defined(pclinux,var): include(gog/gog.pri)
 win32|macx|defined(pclinux,var)|defined(armlinux,var): include(es2/es2.pri)
 win32: include(launchbox/launchbox.pri)
 win32: include(playnite/playnite.pri)
+win32: include(epicgames/epicgames.pri)
 android: include(android_apps/android.pri)
 defined(pclinux,var): include(lutris/lutris.pri)
 # All platforms


### PR DESCRIPTION
This PR adds an Epic Games provider to automatically populate games installed with Epic Games. Implements part of #671

I basically just copied the code for the Steam provider so feel free to make suggestions - I'm not too familiar with modern C++.

I still need to add some metadata parser but I'm struggling with using the info in the manifest file to retrieve the metadata. I will investigate when I get some time.

Perhaps it's worth cleaning this up and merging without the metadata provider? Let me know.