### PR TITLE
Fix QLatin1String error for flatpak

### DIFF
--- a/src/backend/ProcessLauncher.cpp
+++ b/src/backend/ProcessLauncher.cpp
@@ -165,7 +165,7 @@ void ProcessLauncher::onLaunchRequested(const model::GameFile* q_gamefile)
 
     const QString raw_launch_cmd =
 #if defined(Q_OS_LINUX) && defined(PEGASUS_INSIDE_FLATPAK)
-        QLatin1String("flatpak-spawn --host ") % game.launchCmd();
+        QLatin1String("flatpak-spawn --host ") + game.launchCmd();
 #else
         game.launchCmd();
 #endif


### PR DESCRIPTION
Flatpak builds were failing for several months, unfortunately I'm notified for CI errors in master - only for PRs. I'm looking for a solution.

The error here is:
```
/run/build/pegasus-frontend/src/backend/ProcessLauncher.cpp: In member function ‘void ProcessLauncher::onLaunchRequested(const model::GameFile*)’:
/run/build/pegasus-frontend/src/backend/ProcessLauncher.cpp:168:48: error: no match for ‘operator%’ (operand types are ‘QLatin1String’ and ‘const QString’)
  168 |         QLatin1String("flatpak-spawn --host ") % game.launchCmd();
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~
      |         |                                                      |
      |         QLatin1String                                          const QString
```

Replacing the `%` by a `+` makes the flatpak build.
Launching flatpaks inside Pegasus works,