### PR TITLE
Metadata Provider: Improve startup times by avoiding directory scanning

### DIFF
--- a/src/backend/providers/pegasus_metadata/PegasusFilter.cpp
+++ b/src/backend/providers/pegasus_metadata/PegasusFilter.cpp
@@ -145,7 +145,7 @@ void apply_filter(FileFilter& filter, SearchContext& sctx)
 
     const bool has_valid_regex = !filter.include.regex.pattern().isEmpty() && filter.include.regex.isValid();
     const bool needs_scan = !filter.include.extensions.empty() || has_valid_regex;
-    if (!needs_scan)
+    if (!AppSettings::general.verify_files || !needs_scan)
         return;
 
     constexpr auto entry_filters_files = QDir::Files | QDir::NoDotAndDotDot;

--- a/src/backend/providers/pegasus_metadata/PegasusProvider.cpp
+++ b/src/backend/providers/pegasus_metadata/PegasusProvider.cpp
@@ -44,6 +44,16 @@ std::vector<QString> find_metafiles_in(const QString& dir_path)
 
     std::vector<QString> result;
 
+    QDir dir(dir_path);
+
+    // look for standalone files first, to avoid reading the entire directory
+    if (dir.exists("metadata.pegasus.txt")) {
+        return { QDir::cleanPath(dir_path + QDir::separator() + "metadata.pegasus.txt") };
+    } else if (dir.exists("metadata.txt")) {
+        return { QDir::cleanPath(dir_path + QDir::separator() + "metadata.txt") };
+    }
+
+    // else look for wildcard metadata files
     QDirIterator dir_it(dir_path, dir_filters, dir_flags);
     while (dir_it.hasNext()) {
         dir_it.next();


### PR DESCRIPTION
There are a few open Issues sharing problems with Android startup times being slow, especially if there are a lot of files and directories to parse.

For example: e.g. https://github.com/mmatyas/pegasus-frontend/issues/937 and https://github.com/mmatyas/pegasus-frontend/issues/839

On one of my devices (Anbernic RG405M), I am using Pegasus with 30+ directories and 40k+ files, each with their own screenshot.  Each directory has a complete `metadata.pegasus.txt` covering all of the files.  Pegasus is regularly taking over a minute to start up.  This is frustratingly slow, so I looked for opportunities to make it faster.

In profiling the application startup, one thing I found is that the `pegasus_metadata` provider uses a `QDirIterator` to go over each directory's contents, when it's looking for matching `metadata.pegasus.txt`, `metadata.txt` or `*.metadata.pegasus.txt` files.  I don't know a ton about QT, but from a few threads I've read, `QDirIterator` may run a `stat()` on each file it finds (requesting more details from the file system).  This is a lot more expensive than just getting a list of file names (with no details), which likely contributes to a slow directory processing time when reading directories with a lot of files.

It also appears we do a full `QDirIterator` on each directory at least twice:

* Once to find all `*metadata*.txt` files
* Once to find all files that match the metadata's include/exclude list of file extensions

I tried a couple ways of making startup faster.  Here are some startup time results for my tests:

* Latest Pegasus with _Only show existing games_ checked: 222s
* Latest Pegasus with _Only show existing games_ disabled: 50s
* Applying a [`nameFilter`](https://doc.qt.io/qt-5/qdiriterator.html#QDirIterator-3) to the iterator and specifying only `metadata.pegasus.txt`, `metadata.txt`, `*.metadata.pegasus.txt` and `*.metadata.txt`: 50s (same as above)
    * (looks like internally, the `nameFilter` must still get and `stat()` all files before returning, so this didn't save any time)
* Trying to use `QDir::entryList()` instead of a `QDirIterator` - 50s (same as above)
    * (looks like internally, this calls `QDirIterator`)

So, none of the above changes helped.

I believe each of the two `QDirIterators` phases was contributing to about 20-25s of startup time, so next I looked to find a way to avoid `QDirIterator` entirely.

## Avoiding the first `QDirIterator`

One fix we could apply to save time: when looking for matching metadata files, run a small `QDir::exists()` check on just `metadata.pegasus.txt` and `metadata.txt` first and return immediately without a full directory scan if so (avoiding the slow `stat()` calls to the other files).

In the "best case" scenario (where `metadata.pegasus.txt` exists), this eliminates a `QDirIterator` pass entirely, reducing startup time in half (to about 25s).

One downside of doing this: It _could_ cause a compatibility concern if people have both a `metadata.pegasus.txt` and then additional `*.metadata.pegasus.txt` files.  Do we expect that to be common?  I think we could explain this limitation in the release notes and wiki to avoid confusion: use one or the other file naming scheme, not both.

## Avoiding the second `QDirIterator`

I reviewed the remaining 25 seconds of startup time, and most of it was spent doing the second `QDirIterator`.  This happens after the metadata files have been parsed, in `PegasusFilter.cpp`, when applying the include/exclude list to the list of file extensions.  It's looking for additional files to include dynamically, if I understand it correctly?

*As far as I can tell*, this step isn't necessary if you have a "full" metadata file (with all of the files you want defined already), and have _Only show existing games_ unchecked.  I think, in the spirit of https://github.com/mmatyas/pegasus-frontend/pull/899, we should avoid doing this inclusion/exclusion scan if that option is un-checked.  In that case, we "trust" the metadata file to be the complete view of the world and shouldn't be looking at the disk.

This removes the second `QDirIterator` entirely.

## Results

On my Android device that was taking 50+ seconds to show the theme, it now loads in under 5 seconds.  The rest of the startup time is mostly spent parsing the `metadata.pegasus.txt` file format.  On my faster devices, the theme loads near instantly (except for Media processing, which I have a separate PR for).