### PR TITLE
Media Provider: Un-mark as internal so it can be optionally disabled

### DIFF
--- a/src/backend/providers/pegasus_media/MediaProvider.cpp
+++ b/src/backend/providers/pegasus_media/MediaProvider.cpp
@@ -88,7 +88,7 @@ namespace providers {
 namespace media {
 
 MediaProvider::MediaProvider(QObject* parent)
-    : Provider(QLatin1String("pegasus_media"), QStringLiteral("Media"), PROVIDER_FLAG_INTERNAL, parent)
+    : Provider(QLatin1String("pegasus_media"), QStringLiteral("Media"), parent)
 {}
 
 Provider& MediaProvider::run(SearchContext& sctx)


### PR DESCRIPTION
Alongside some Android startup improvements in https://github.com/mmatyas/pegasus-frontend/pull/1089, I found that the Media processing was taking a long time during Pegasus startup.

For example, on an Anbernic RG405M device with 40k+ screenshots, it's taking over 32s:

```
2023-11-08T15:49:55 [i] Media: Finished searching in 32105ms
```

Guided by a comment in https://github.com/mmatyas/pegasus-frontend/issues/839#issuecomment-1087747818, I tried disabling the Media provider, and it cut out this delay entirely.

After I did this, I reviewed my theme and could not find any side-effects -- all screenshots were continuing to load OK.  I reviewed its code, and could not find other obvious places its output would be used, so I must be missing something.  Is there something the MediaProvider is doing that I'm breaking by disabling it?

Anyways, for my use-case, it seems like avoiding the MediaProvider is beneficial (faster startup) and causes no side-effects.

This PR un-marks the `MediaProvider` as internal, so that users can optionally disable it in via just the UI, instead of building a custom APK.

![image](https://github.com/mmatyas/pegasus-frontend/assets/1004649/6da88d6c-7ebf-4761-8334-bf68ca327832)
