### PR TITLE
filter lutris games to ones installed

### DIFF
--- a/src/backend/providers/lutris/LutrisProvider.cpp
+++ b/src/backend/providers/lutris/LutrisProvider.cpp
@@ -140,7 +140,7 @@ Provider& LutrisProvider::run(SearchContext& sctx)
         return *this;
 
     QSqlQuery query;
-    query.prepare(QLatin1String("SELECT * FROM games"));
+    query.prepare(QLatin1String("SELECT * FROM games WHERE installed = 1"));
     if (!query.exec()) {
         Log::warning(display_name(), LOGMSG("Could not query game data: %1").arg(query.lastError().text()));
         return *this;


### PR DESCRIPTION
I noticed that games I had uninstalled were appearing in the list, the sqlite db you're reading from appears to include uninstalled entries