### PR TITLE
Make the URI escaping match the system implementation on Android

### DIFF
--- a/src/backend/platform/AndroidHelpers.cpp
+++ b/src/backend/platform/AndroidHelpers.cpp
@@ -200,7 +200,7 @@ QString to_document_uri(const QString& path)
     const QString rel_path = prefix + storage_root.relativeFilePath(abs_path);
 
     const QString uri_str = QStringLiteral("content://com.android.externalstorage.documents/tree/%1/document/%2")
-        .arg(QUrl::toPercentEncoding(rel_dir), QUrl::toPercentEncoding(rel_path));
+        .arg(QUrl::toPercentEncoding(rel_dir, "_-!.~'()*"), QUrl::toPercentEncoding(rel_path));
 
     return uri_str;
 }


### PR DESCRIPTION
There is a difference between what Qt (`QUrl::toPercentEncoding`) and the Android Uri implementation (https://developer.android.com/reference/android/net/Uri) considers as reserved character.