### PR TITLE
Add "fileExists" flag to Game Model to indicate when a game is installed or not

### DIFF
--- a/src/backend/AppSettings.h
+++ b/src/backend/AppSettings.h
@@ -42,6 +42,7 @@ struct General {
     bool fullscreen = true;
     bool mouse_support = true;
     bool verify_files = true;
+    bool show_missing_games = false;
     QString locale;
     QString theme;
 

--- a/src/backend/model/gaming/Game.cpp
+++ b/src/backend/model/gaming/Game.cpp
@@ -66,6 +66,12 @@ Game& Game::setFavorite(bool new_val)
     return *this;
 }
 
+Game& Game::setMissing(bool new_val)
+{
+    m_data.missing = new_val;
+    return *this;
+}
+
 Game& Game::setRating(float rating)
 {
     m_data.rating = qBound(0.f, rating, 1.f);

--- a/src/backend/model/gaming/Game.h
+++ b/src/backend/model/gaming/Game.h
@@ -60,6 +60,7 @@ struct GameData {
     } playstats;
 
     bool is_favorite = false;
+    bool missing = false;
 
     struct LaunchParams {
         QString launch_cmd;
@@ -97,6 +98,7 @@ public:
     GETTER(int, playTime, playstats.play_time)
     GETTER(const QDateTime&, lastPlayed, playstats.last_played)
     GETTER(bool, isFavorite, is_favorite)
+    GETTER(bool, isMissing, missing)
 
     GETTER(const QString&, launchCmd, launch_params.launch_cmd)
     GETTER(const QString&, launchWorkdir, launch_params.launch_workdir)
@@ -120,6 +122,7 @@ public:
     Game& setFavorite(bool val);
     Game& setRating(float rating);
     Game& setPlayerCount(int player_count);
+    Game& setMissing(bool val);
 #undef SETTER
 
 
@@ -153,6 +156,7 @@ public:
     Q_PROPERTY(int playTime READ playTime NOTIFY playStatsChanged)
     Q_PROPERTY(QDateTime lastPlayed READ lastPlayed NOTIFY playStatsChanged)
     Q_PROPERTY(bool favorite READ isFavorite WRITE setFavorite NOTIFY favoriteChanged)
+    Q_PROPERTY(bool missing READ isMissing WRITE setMissing NOTIFY missingChanged)
 
     Q_PROPERTY(QVariantMap extra READ extraMap CONSTANT)
     const QVariantMap& extraMap() const { return m_extra; }
@@ -186,6 +190,7 @@ signals:
     void launchFileSelectorRequested();
     void favoriteChanged();
     void playStatsChanged();
+    void missingChanged();
 
 private slots:
     void onEntryPlayStatsChanged();

--- a/src/backend/model/gaming/GameListModel.cpp
+++ b/src/backend/model/gaming/GameListModel.cpp
@@ -40,6 +40,7 @@ enum Roles {
     PlayTime,
     LastPlayed,
     Favorite,
+    Missing,
     Extra,
     Developer,
     DeveloperList,
@@ -80,6 +81,7 @@ QHash<int, QByteArray> GameListModel::roleNames() const
         { Roles::PlayTime, QByteArrayLiteral("playTime") },
         { Roles::LastPlayed, QByteArrayLiteral("lastPlayed") },
         { Roles::Favorite, QByteArrayLiteral("favorite") },
+        { Roles::Missing, QByteArrayLiteral("missing") },
         { Roles::Extra, QByteArrayLiteral("extra") },
         { Roles::Developer, QByteArrayLiteral("developer") },
         { Roles::DeveloperList, QByteArrayLiteral("developerList") },
@@ -120,6 +122,7 @@ QVariant GameListModel::data(const QModelIndex& index, int role) const
         case Roles::PlayTime: return game.playTime();
         case Roles::LastPlayed: return game.lastPlayed();
         case Roles::Favorite: return game.isFavorite();
+        case Roles::Missing: return game.isMissing();
         case Roles::Extra: return game.extraMap();
         case Roles::Developer: return game.developerStr();
         case Roles::DeveloperList: return game.developerListConst();
@@ -141,6 +144,8 @@ void GameListModel::connectEntry(model::Game* const game)
 {
     connect(game, &model::Game::favoriteChanged,
             this, [this](){ onGamePropertyChanged({Roles::Favorite}); });
+    connect(game, &model::Game::missingChanged,
+            this, [this](){ onGamePropertyChanged({Roles::Missing}); });
     connect(game, &model::Game::playStatsChanged,
             this, [this](){ onGamePropertyChanged({Roles::PlayCount, Roles::PlayTime, Roles::LastPlayed}); });
 }

--- a/src/backend/model/internal/settings/Settings.cpp
+++ b/src/backend/model/internal/settings/Settings.cpp
@@ -115,6 +115,17 @@ void Settings::setVerifyFiles(bool new_val)
     emit verifyFilesChanged();
 }
 
+void Settings::setShowMissingGames(bool new_val)
+{
+    if (new_val == AppSettings::general.show_missing_games)
+        return;
+
+    AppSettings::general.show_missing_games = new_val;
+    AppSettings::save_config();
+
+    emit showMissingGamesChanged();
+}
+
 QStringList Settings::gameDirs() const
 {
     QSet<QString> dirset;

--- a/src/backend/model/internal/settings/Settings.h
+++ b/src/backend/model/internal/settings/Settings.h
@@ -42,6 +42,9 @@ class Settings : public QObject {
     Q_PROPERTY(bool verifyFiles
                READ verifyFiles WRITE setVerifyFiles
                NOTIFY verifyFilesChanged)
+    Q_PROPERTY(bool showMissingGames
+               READ showMissingGames WRITE setShowMissingGames
+               NOTIFY showMissingGamesChanged)
     Q_PROPERTY(QStringList gameDirs READ gameDirs NOTIFY gameDirsChanged)
     Q_PROPERTY(QStringList androidGrantedDirs READ androidGrantedDirs NOTIFY androidDirsChanged)
 
@@ -63,6 +66,9 @@ public:
     bool verifyFiles() const { return AppSettings::general.verify_files; }
     void setVerifyFiles(bool);
 
+    bool showMissingGames() const { return AppSettings::general.show_missing_games; }
+    void setShowMissingGames(bool);
+
     QStringList gameDirs() const;
     Q_INVOKABLE void addGameDir(const QString&);
     Q_INVOKABLE void removeGameDirs(const QVariantList&);
@@ -76,6 +82,7 @@ signals:
     void fullscreenChanged();
     void mouseSupportChanged();
     void verifyFilesChanged();
+    void showMissingGamesChanged();
     void gameDirsChanged();
     void androidDirsChanged();
     void providerReloadingRequested();

--- a/src/backend/parsers/SettingsFile.cpp
+++ b/src/backend/parsers/SettingsFile.cpp
@@ -69,6 +69,7 @@ ConfigEntryMaps::ConfigEntryMaps()
         { QStringLiteral("fullscreen"), GeneralOption::FULLSCREEN },
         { QStringLiteral("input-mouse-support"), GeneralOption::MOUSE_SUPPORT },
         { QStringLiteral("verify-files"), GeneralOption::VERIFY_FILES },
+        { QStringLiteral("show-missing-games"), GeneralOption::SHOW_MISSING_GAMES },
         { QStringLiteral("locale"), GeneralOption::LOCALE },
         { QStringLiteral("theme"), GeneralOption::THEME },
     }
@@ -173,6 +174,10 @@ void LoadContext::handle_general_attrib(const size_t lineno, const QString& key,
             break;
         case ConfigEntryGeneralOption::VERIFY_FILES:
             if (!store_bool_maybe(val, AppSettings::general.verify_files))
+                log_needs_bool(lineno, key);
+            break;
+        case ConfigEntryGeneralOption::SHOW_MISSING_GAMES:
+            if (!store_bool_maybe(val, AppSettings::general.show_missing_games))
                 log_needs_bool(lineno, key);
             break;
         case ConfigEntryGeneralOption::LOCALE:
@@ -307,6 +312,7 @@ void SaveContext::print_general(QTextStream& stream) const
         { GeneralOption::FULLSCREEN, AppSettings::general.fullscreen ? STR_TRUE : STR_FALSE },
         { GeneralOption::MOUSE_SUPPORT, AppSettings::general.mouse_support ? STR_TRUE : STR_FALSE },
         { GeneralOption::VERIFY_FILES, AppSettings::general.verify_files ? STR_TRUE : STR_FALSE },
+        { GeneralOption::SHOW_MISSING_GAMES, AppSettings::general.show_missing_games ? STR_TRUE : STR_FALSE },
         { GeneralOption::LOCALE, AppSettings::general.locale },
         { GeneralOption::THEME, theme_path },
     };

--- a/src/backend/parsers/SettingsFile.h
+++ b/src/backend/parsers/SettingsFile.h
@@ -38,6 +38,7 @@ enum class ConfigEntryGeneralOption : unsigned char {
     FULLSCREEN,
     MOUSE_SUPPORT,
     VERIFY_FILES,
+    SHOW_MISSING_GAMES,
     LOCALE,
     THEME,
 };

--- a/src/backend/providers/pegasus_metadata/PegasusFilter.cpp
+++ b/src/backend/providers/pegasus_metadata/PegasusFilter.cpp
@@ -138,7 +138,7 @@ void apply_filter(FileFilter& filter, SearchContext& sctx)
     for (const QString& filepath: include_files) {
         if (VEC_CONTAINS(exclude_files, filepath))
             continue;
-        if (AppSettings::general.verify_files && !QFileInfo::exists(filepath))
+        if (AppSettings::general.verify_files && !AppSettings::general.show_missing_games && !QFileInfo::exists(filepath))
             continue;
         accept_filtered_file(filepath, collection, sctx);
     }

--- a/src/backend/providers/pegasus_metadata/PegasusMetadata.cpp
+++ b/src/backend/providers/pegasus_metadata/PegasusMetadata.cpp
@@ -318,7 +318,9 @@ void Metadata::apply_game_entry(ParserState& ps, const metafile::Entry& entry, S
                     QFileInfo finfo(ps.dir, line);
                     if (AppSettings::general.verify_files && !finfo.exists()) {
                         print_warning(ps, entry, LOGMSG("Game file `%1` doesn't seem to exist").arg(::pretty_path(finfo)));
-                        continue;
+                        ps.cur_game->setMissing(true);
+                        if (!AppSettings::general.show_missing_games)
+                            continue;
                     }
 
                     QString path = ::clean_abs_path(finfo);

--- a/src/frontend/menu/settings/SettingsMain.qml
+++ b/src/frontend/menu/settings/SettingsMain.qml
@@ -124,12 +124,21 @@ FocusScope {
             enabled: Qt.platform.os === "android"
         },
         SettingsEntry {
-            label: QT_TR_NOOP("Only show existing games")
+            label: QT_TR_NOOP("Validate game files")
             desc: QT_TR_NOOP("Check the game files and only show games that actually exist. You can disable this to improve loading times.")
             type: SettingsEntry.Type.Bool
             boolValue: Internal.settings.verifyFiles
             boolSetter: (val) => Internal.settings.verifyFiles = val
             section: "gaming"
+        },
+        SettingsEntry {
+            label: QT_TR_NOOP("Show missing games")
+            desc: QT_TR_NOOP("Show all detected games, including those that may not exist.")
+            type: SettingsEntry.Type.Bool
+            boolValue: Internal.settings.showMissingGames
+            boolSetter: (val) => Internal.settings.showMissingGames = val
+            section: "gaming"
+            enabled: Internal.settings.verifyFiles
         },
         SettingsEntry {
             label: QT_TR_NOOP("Enable/disable data sources...")
@@ -156,6 +165,7 @@ FocusScope {
                 desc: qsTr(model.desc) + api.tr
                 checked: model.boolValue
                 onCheckedChanged: model.boolSetter(checked)
+                enabled: model.enabled
             }
         }
 

--- a/src/frontend/menu/settings/common/ToggleOption.qml
+++ b/src/frontend/menu/settings/common/ToggleOption.qml
@@ -30,7 +30,7 @@ FocusScope {
 
     width: parent.width
     height: labelContainer.height + fontSize * 1.25
-
+    opacity: enabled ? 1.0 : 0.25
 
     Rectangle {
         id: underline


### PR DESCRIPTION
This PR adds a new Boolean "fileExists" to the game model that can be leveraged in Themes to indicate when a Game is currently installed or not.

By default, Pegasus currently checks for the existence of game files, and if a file is not found, it logs the missing game and does not add it to the Collection so from the Theme perspective it doesn't exist.  This setting can be disabled with the "verify_files" flag in Pegasus config at which point the current behavior is to skip the file check entirely.

This PR adds a second Boolean toggle "show_missing_files" that, when the "verify_files" flag is true will set the fileExists flag on the Game metadata based on whether or not the file exists.  In order to maintain backwards compatibility with existing themes, I left the original verify_files unchanged so it should not impact existing installations that do not enable this setting.

Other notes
- I only enabled this feature on the "Pegasus Metadata" Provider currently, as I only use this format so I don't have a way to easily test/verify functionality on other providers.
- I will submit a second PR incorporating this flag usage into the default Grid theme (I'll submit it to the standalone version of the theme first, but if the changes look good, I can also submit to the built-in version of the grid theme in this repo).

Open to any feedback / changes you would like to see in this before merging.