### PR TITLE
Temporarily disable the macOS builds due to QTBUG-117225

### DIFF
--- a/.circleci/release_github.sh
+++ b/.circleci/release_github.sh
@@ -17,7 +17,6 @@ TARGETS=" \
   rpi2-static \
   rpi3-static \
   rpi4-static \
-  macos-static \
   android \
   android64 \
   win32-mingw-static \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,5 @@
 name: Build - MacOS
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_dispatch]
 
 env:
   TOOLS_URL: https://github.com/mmatyas/pegasus-frontend/releases/download/alpha1


### PR DESCRIPTION
Why would things work, am I right?