### PR TITLE
Add support for game URIs to stats.db

### DIFF
--- a/src/backend/model/gaming/GameFile.h
+++ b/src/backend/model/gaming/GameFile.h
@@ -36,6 +36,7 @@ struct GameFileData {
     const QString path;
     const QFileInfo fileinfo;
     QString name;
+    QString uri;
 
     // TODO: in the future...
     // QString summary;
@@ -60,6 +61,9 @@ public:
     const QString& name() const { return m_data.name; }
     GameFile& setName(QString val) { m_data.name = std::move(val); return *this; }
     QString path() const { return m_data.fileinfo.filePath(); }
+    const QString& uri() const { return m_data.uri; }
+    GameFile& setURI(QString val) { m_data.uri = std::move(val); return *this; }
+    bool hasURI() const { return !m_data.uri.isEmpty(); }
     Q_PROPERTY(QString name READ name CONSTANT)
     Q_PROPERTY(QString path READ path CONSTANT)
 

--- a/src/backend/model/gaming/GameFile.h
+++ b/src/backend/model/gaming/GameFile.h
@@ -66,6 +66,7 @@ public:
     bool hasUri() const { return !m_data.uri.isEmpty(); }
     Q_PROPERTY(QString name READ name CONSTANT)
     Q_PROPERTY(QString path READ path CONSTANT)
+    Q_PROPERTY(QString uri READ uri CONSTANT)
 
     int playCount() const { return m_data.playstats.play_count; }
     qint64 playTime() const { return m_data.playstats.play_time; }

--- a/src/backend/model/gaming/GameFile.h
+++ b/src/backend/model/gaming/GameFile.h
@@ -62,8 +62,8 @@ public:
     GameFile& setName(QString val) { m_data.name = std::move(val); return *this; }
     QString path() const { return m_data.fileinfo.filePath(); }
     const QString& uri() const { return m_data.uri; }
-    GameFile& setURI(QString val) { m_data.uri = std::move(val); return *this; }
-    bool hasURI() const { return !m_data.uri.isEmpty(); }
+    GameFile& setUri(QString val) { m_data.uri = std::move(val); return *this; }
+    bool hasUri() const { return !m_data.uri.isEmpty(); }
     Q_PROPERTY(QString name READ name CONSTANT)
     Q_PROPERTY(QString path READ path CONSTANT)
 

--- a/src/backend/providers/SearchContext.cpp
+++ b/src/backend/providers/SearchContext.cpp
@@ -155,10 +155,10 @@ model::GameFile* SearchContext::game_add_uri(model::Game& game, QString uri)
         return registered_ptr;
 
     auto* const entry_ptr = new model::GameFile(uri, game);
-    entry_ptr->setURI(uri);
+    entry_ptr->setUri(uri);
     m_game_entries[&game].emplace_back(entry_ptr);
     m_uri_to_gamefile.emplace(uri, entry_ptr);
-    m_filepath_to_gamefile.emplace(entry_ptr->fileinfo().absoluteFilePath(), entry_ptr); // backwards compatibility with old relative path database
+    m_filepath_to_gamefile.emplace(::clean_abs_path(entry_ptr->fileinfo()), entry_ptr); // backwards compatibility with old relative path database
     return entry_ptr;
 }
 

--- a/src/backend/providers/SearchContext.cpp
+++ b/src/backend/providers/SearchContext.cpp
@@ -155,8 +155,10 @@ model::GameFile* SearchContext::game_add_uri(model::Game& game, QString uri)
         return registered_ptr;
 
     auto* const entry_ptr = new model::GameFile(uri, game);
+    entry_ptr->setURI(uri);
     m_game_entries[&game].emplace_back(entry_ptr);
     m_uri_to_gamefile.emplace(uri, entry_ptr);
+    m_filepath_to_gamefile.emplace(entry_ptr->fileinfo().absoluteFilePath(), entry_ptr); // backwards compatibility with old relative path database
     return entry_ptr;
 }
 

--- a/src/backend/providers/pegasus_playtime/PlaytimeStats.cpp
+++ b/src/backend/providers/pegasus_playtime/PlaytimeStats.cpp
@@ -325,8 +325,9 @@ void PlaytimeStats::start_processing()
 
                 const QString path = ::clean_abs_path(entry.gamefile->fileinfo());
                 const int old_path_id = get_path_id(display_name(), path, false);
+                // no path ID to migrate
                 if (old_path_id == -1)
-                    continue; // no path ID to migrate
+                    continue;
 
                 const int new_path_id = get_path_id(display_name(), uri);
                 if (new_path_id >= 0) {

--- a/src/backend/providers/pegasus_playtime/PlaytimeStats.cpp
+++ b/src/backend/providers/pegasus_playtime/PlaytimeStats.cpp
@@ -85,7 +85,7 @@ bool create_missing_tables(const QString& log_tag, SqliteDb& channel)
     return true;
 }
 
-int get_path_id(const QString& log_tag, const QString& game_key, bool do_insert = true)
+int get_path_id(const QString& log_tag, const QString& game_key, bool insert_on_missing = true)
 {
     {
         QSqlQuery query;
@@ -99,7 +99,7 @@ int get_path_id(const QString& log_tag, const QString& game_key, bool do_insert 
             return query.value(0).toInt();
     }
     // no hit -> insert
-    if (do_insert) {
+    if (insert_on_missing) {
         QSqlQuery query;
         query.prepare(QStringLiteral("INSERT INTO paths VALUES(null, ?);"));
         query.addBindValue(game_key);
@@ -108,7 +108,7 @@ int get_path_id(const QString& log_tag, const QString& game_key, bool do_insert 
             return -1;
         }
     }
-    if (do_insert) {
+    if (insert_on_missing) {
         QSqlQuery query;
         query.prepare(QStringLiteral("SELECT last_insert_rowid() FROM paths;"));
         if (!query.exec()) {
@@ -147,8 +147,10 @@ void migrate_play_entry(const QString& log_tag, int old_path_id, int new_path_id
     update_plays_query.prepare(QStringLiteral("UPDATE plays SET path_id = ? WHERE path_id = ?;"));
     update_plays_query.addBindValue(new_path_id);
     update_plays_query.addBindValue(old_path_id);
-    if (!update_plays_query.exec())
+    if (!update_plays_query.exec()) {
         print_query_error(log_tag, update_plays_query);
+        return;
+    }
 
     // delete old path
     QSqlQuery delete_path_query;
@@ -222,7 +224,7 @@ Provider& PlaytimeStats::run(SearchContext& sctx)
         if (!game_ptr) {
             game_ptr = sctx.gamefile_by_filepath(path);
             // schedule a data migration if path is being used for a URI game
-            if (game_ptr && game_ptr->hasURI())
+            if (game_ptr && game_ptr->hasUri())
                 m_pending_migrations.emplace_back(game_ptr);
         }
         if (!game_ptr)
@@ -246,7 +248,7 @@ Provider& PlaytimeStats::run(SearchContext& sctx)
     }
 
     // process any migrations
-    if (m_active_tasks.empty())
+    if (m_active_migrations.empty())
         start_processing();
 
     return *this;
@@ -280,7 +282,7 @@ void PlaytimeStats::onGameFinished(model::GameFile* const gamefile)
 
 void PlaytimeStats::start_processing()
 {
-    Q_ASSERT(m_active_tasks.empty());
+    Q_ASSERT(m_active_tasks.empty() || m_active_migrations.empty());
 
     m_active_tasks.swap(m_pending_tasks);
     m_active_migrations.swap(m_pending_migrations);
@@ -307,7 +309,7 @@ void PlaytimeStats::start_processing()
             }
 
             for (const QueueEntry& entry : m_active_tasks) {
-                const QString path = entry.gamefile->hasURI()
+                const QString path = entry.gamefile->hasUri()
                     ? entry.gamefile->uri()
                     : ::clean_abs_path(entry.gamefile->fileinfo());
                 const int path_id = get_path_id(display_name(), path);
@@ -317,12 +319,14 @@ void PlaytimeStats::start_processing()
 
             for (const MigrationQueueEntry& entry : m_active_migrations) {
                 // we don't have a uri to migrate??
-                if (!entry.gamefile->hasURI()) continue;
+                if (!entry.gamefile->hasUri())
+                    continue;
                 const QString uri = entry.gamefile->uri();
 
                 const QString path = ::clean_abs_path(entry.gamefile->fileinfo());
                 const int old_path_id = get_path_id(display_name(), path, false);
-                if (old_path_id == -1) continue; // no path ID to migrate
+                if (old_path_id == -1)
+                    continue; // no path ID to migrate
 
                 const int new_path_id = get_path_id(display_name(), uri);
                 if (new_path_id >= 0) {

--- a/src/backend/providers/pegasus_playtime/PlaytimeStats.cpp
+++ b/src/backend/providers/pegasus_playtime/PlaytimeStats.cpp
@@ -85,7 +85,7 @@ bool create_missing_tables(const QString& log_tag, SqliteDb& channel)
     return true;
 }
 
-int get_path_id(const QString& log_tag, const QString& game_key)
+int get_path_id(const QString& log_tag, const QString& game_key, bool do_insert = true)
 {
     {
         QSqlQuery query;
@@ -99,7 +99,7 @@ int get_path_id(const QString& log_tag, const QString& game_key)
             return query.value(0).toInt();
     }
     // no hit -> insert
-    {
+    if (do_insert) {
         QSqlQuery query;
         query.prepare(QStringLiteral("INSERT INTO paths VALUES(null, ?);"));
         query.addBindValue(game_key);
@@ -108,7 +108,7 @@ int get_path_id(const QString& log_tag, const QString& game_key)
             return -1;
         }
     }
-    {
+    if (do_insert) {
         QSqlQuery query;
         query.prepare(QStringLiteral("SELECT last_insert_rowid() FROM paths;"));
         if (!query.exec()) {
@@ -135,6 +135,27 @@ void save_play_entry(const QString& log_tag, const int path_id, const QDateTime&
     query.addBindValue(duration);
     if (!query.exec())
         print_query_error(log_tag, query);
+}
+
+void migrate_play_entry(const QString& log_tag, int old_path_id, int new_path_id)
+{
+    Q_ASSERT(old_path_id != -1);
+    Q_ASSERT(new_path_id != -1);
+
+    // update plays to use new path
+    QSqlQuery update_plays_query;
+    update_plays_query.prepare(QStringLiteral("UPDATE plays SET path_id = ? WHERE path_id = ?;"));
+    update_plays_query.addBindValue(new_path_id);
+    update_plays_query.addBindValue(old_path_id);
+    if (!update_plays_query.exec())
+        print_query_error(log_tag, update_plays_query);
+
+    // delete old path
+    QSqlQuery delete_path_query;
+    delete_path_query.prepare(QStringLiteral("DELETE FROM paths WHERE id = ?;"));
+    delete_path_query.addBindValue(old_path_id);
+    if (!delete_path_query.exec())
+        print_query_error(log_tag, delete_path_query);
 }
 
 void update_modelgame(model::GameFile* const gamefile, const QDateTime& start_time, const qint64 duration)
@@ -193,9 +214,17 @@ Provider& PlaytimeStats::run(SearchContext& sctx)
     };
     HashMap<model::GameFile*, Stats> stat_map;
 
+    QMutexLocker lock(&m_queue_guard);
+
     while (query.next()) {
         const QString path = query.value(0).toString();
-        model::GameFile* const game_ptr = sctx.gamefile_by_filepath(path); // TODO: URI support
+        model::GameFile* game_ptr = sctx.gamefile_by_uri(path);
+        if (!game_ptr) {
+            game_ptr = sctx.gamefile_by_filepath(path);
+            // schedule a data migration if path is being used for a URI game
+            if (game_ptr && game_ptr->hasURI())
+                m_pending_migrations.emplace_back(game_ptr);
+        }
         if (!game_ptr)
             continue;
 
@@ -215,6 +244,10 @@ Provider& PlaytimeStats::run(SearchContext& sctx)
         const Stats& stats = pair.second;
         gamefile->update_playstats(stats.playcount, stats.playtime, stats.last_played);
     }
+
+    // process any migrations
+    if (m_active_tasks.empty())
+        start_processing();
 
     return *this;
 }
@@ -250,11 +283,12 @@ void PlaytimeStats::start_processing()
     Q_ASSERT(m_active_tasks.empty());
 
     m_active_tasks.swap(m_pending_tasks);
+    m_active_migrations.swap(m_pending_migrations);
 
     QtConcurrent::run([this]{
         emit startedWriting();
 
-        while (!m_active_tasks.empty()) {
+        while (!m_active_tasks.empty() || !m_active_migrations.empty()) {
             for (const QueueEntry& entry : m_active_tasks)
                 update_modelgame(entry.gamefile, entry.launch_time, entry.duration);
 
@@ -273,10 +307,28 @@ void PlaytimeStats::start_processing()
             }
 
             for (const QueueEntry& entry : m_active_tasks) {
-                const QString path = ::clean_abs_path(entry.gamefile->fileinfo());
+                const QString path = entry.gamefile->hasURI()
+                    ? entry.gamefile->uri()
+                    : ::clean_abs_path(entry.gamefile->fileinfo());
                 const int path_id = get_path_id(display_name(), path);
                 if (path_id >= 0)
                     save_play_entry(display_name(), path_id, entry.launch_time, entry.duration);
+            }
+
+            for (const MigrationQueueEntry& entry : m_active_migrations) {
+                // we don't have a uri to migrate??
+                if (!entry.gamefile->hasURI()) continue;
+                const QString uri = entry.gamefile->uri();
+
+                const QString path = ::clean_abs_path(entry.gamefile->fileinfo());
+                const int old_path_id = get_path_id(display_name(), path, false);
+                if (old_path_id == -1) continue; // no path ID to migrate
+
+                const int new_path_id = get_path_id(display_name(), uri);
+                if (new_path_id >= 0) {
+                    Log::info(LOGMSG("Migrating playtime stats for '%1'.").arg(uri));
+                    migrate_play_entry(display_name(), old_path_id, new_path_id);
+                }
             }
 
             channel.commit();
@@ -285,6 +337,8 @@ void PlaytimeStats::start_processing()
             QMutexLocker lock(&m_queue_guard);
             m_active_tasks.clear();
             m_active_tasks.swap(m_pending_tasks);
+            m_active_migrations.clear();
+            m_active_migrations.swap(m_pending_migrations);
         }
 
         emit finishedWriting();

--- a/src/backend/providers/pegasus_playtime/PlaytimeStats.h
+++ b/src/backend/providers/pegasus_playtime/PlaytimeStats.h
@@ -60,6 +60,17 @@ private:
     };
     std::vector<QueueEntry> m_pending_tasks;
     std::vector<QueueEntry> m_active_tasks;
+
+    struct MigrationQueueEntry {
+        model::GameFile* const gamefile;
+
+        MigrationQueueEntry(model::GameFile* const gamefile)
+            : gamefile(std::move(gamefile))
+        {}
+    };
+    std::vector<MigrationQueueEntry> m_pending_migrations;
+    std::vector<MigrationQueueEntry> m_active_migrations;
+
     QMutex m_queue_guard;
 
     void start_processing();


### PR DESCRIPTION
Adds game URI support/migrations for stats.db

first half of #1097, reference discussion is in there

stats.db before:
```
/home/xela/lutris:hells-kitchen-the-game|1772497607|10
/home/xela/steam:3590|1772601200|25000
/home/xela/Documents/pegasus-frontend/lutris:test-game|1772873221|6
/home/xela/Documents/pegasus-frontend/lutris:test-game|1772875275|7
```
stats.db after:
```
lutris:hells-kitchen-the-game|1772497607|10
steam:3590|1772601200|25000
lutris:test-game|1772873221|6
lutris:test-game|1772875275|7
```

Adds a new property to GameFile `uri` which stores the URI assigned to the game. (eg. steam:xxx)

The old provider simply passed the raw uri to QFileInfo which prepended the CWD to it because it interpreted it as a relative path. (steam:xxx -> /home/xela/steam:xxx)
This legacy behavior is preserved by adding the path to `m_filepath_to_gamefile` (which allows the old stat.db reader to match the correct game)

Added `do_insert` to `get_path_id()`, if specified false, it won't insert a new path ID (used for migration)

I didn't want to create a second entire queue, so i piggybacked `m_pending_migrations` off of `m_pending_tasks` since they are both database tasks. `migrate_play_entry()` will migrate plays from one path ID to a new one and delete the old one.
While initially scanning the database for playtime, any games that have a set URI but are using the legacy path will be queued for migration.

The writer will also now use a URI instead of an absolute path if available.


I'm not sure how to unit test this or if it even needs unit tested, those remain unchanged.
I manually tested this to the best of my ability, but I don't have a very large dataset that needs migrated.

Due to [this comment](https://github.com/mmatyas/pegasus-frontend/issues/1097#issuecomment-4015978069) and my testing, any externally-provided game with a URI (steam/lutris/etc) does not have playtime properly displayed for it without this patch.