### PR TITLE
backend: cache game metadata between scans

### DIFF
--- a/src/backend/AppSettings.h
+++ b/src/backend/AppSettings.h
@@ -42,6 +42,7 @@ struct General {
     bool fullscreen = true;
     bool mouse_support = true;
     bool verify_files = true;
+    bool scan_on_launch = true;
     bool show_missing_games = false;
     QString locale;
     QString theme;

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -241,7 +241,7 @@ void Backend::start()
 {
     m_api_private->settings().postInit();
     onProcessFinished();
-    onScanRequested();
+    onScanRequested(AppSettings::general.scan_on_launch);
 }
 
 void Backend::onScanRequested(const bool force_refresh)

--- a/src/backend/Backend.cpp
+++ b/src/backend/Backend.cpp
@@ -212,7 +212,7 @@ Backend::Backend(const CliArgs& args)
     QObject::connect(m_api_private->settings().keyEditorPtr(), &model::KeyEditor::keysChanged,
                      m_api_public->keysPtr(), &model::Keys::refresh_keys);
     QObject::connect(m_api_private->settingsPtr(), &model::Settings::providerReloadingRequested,
-                     [this](){ onScanRequested(); });
+                     [this](){ onScanRequested(true); });
 
     QObject::connect(m_api_public, &model::ApiObject::favoritesChanged,
                      [this](){ onFavoritesChanged(); });
@@ -244,10 +244,10 @@ void Backend::start()
     onScanRequested();
 }
 
-void Backend::onScanRequested()
+void Backend::onScanRequested(const bool force_refresh)
 {
     m_api_public->clearGameData();
-    m_providerman->run();
+    m_providerman->run(force_refresh);
 }
 
 void Backend::onScanFinished()

--- a/src/backend/Backend.h
+++ b/src/backend/Backend.h
@@ -50,7 +50,7 @@ private:
     ProcessLauncher* m_launcher;
     ProviderManager* m_providerman;
 
-    void onScanRequested();
+    void onScanRequested(bool force_refresh = false);
     void onScanFinished();
     void onFavoritesChanged();
     void onProcessLaunched();

--- a/src/backend/model/internal/settings/Settings.cpp
+++ b/src/backend/model/internal/settings/Settings.cpp
@@ -115,6 +115,17 @@ void Settings::setVerifyFiles(bool new_val)
     emit verifyFilesChanged();
 }
 
+void Settings::setScanOnLaunch(bool new_val)
+{
+    if (new_val == AppSettings::general.scan_on_launch)
+        return;
+
+    AppSettings::general.scan_on_launch = new_val;
+    AppSettings::save_config();
+
+    emit scanOnLaunchChanged();
+}
+
 void Settings::setShowMissingGames(bool new_val)
 {
     if (new_val == AppSettings::general.show_missing_games)

--- a/src/backend/model/internal/settings/Settings.h
+++ b/src/backend/model/internal/settings/Settings.h
@@ -42,6 +42,9 @@ class Settings : public QObject {
     Q_PROPERTY(bool verifyFiles
                READ verifyFiles WRITE setVerifyFiles
                NOTIFY verifyFilesChanged)
+    Q_PROPERTY(bool scanOnLaunch
+               READ scanOnLaunch WRITE setScanOnLaunch
+               NOTIFY scanOnLaunchChanged)
     Q_PROPERTY(bool showMissingGames
                READ showMissingGames WRITE setShowMissingGames
                NOTIFY showMissingGamesChanged)
@@ -66,6 +69,9 @@ public:
     bool verifyFiles() const { return AppSettings::general.verify_files; }
     void setVerifyFiles(bool);
 
+    bool scanOnLaunch() const { return AppSettings::general.scan_on_launch; }
+    void setScanOnLaunch(bool);
+
     bool showMissingGames() const { return AppSettings::general.show_missing_games; }
     void setShowMissingGames(bool);
 
@@ -82,6 +88,7 @@ signals:
     void fullscreenChanged();
     void mouseSupportChanged();
     void verifyFilesChanged();
+    void scanOnLaunchChanged();
     void showMissingGamesChanged();
     void gameDirsChanged();
     void androidDirsChanged();

--- a/src/backend/parsers/SettingsFile.cpp
+++ b/src/backend/parsers/SettingsFile.cpp
@@ -69,6 +69,7 @@ ConfigEntryMaps::ConfigEntryMaps()
         { QStringLiteral("fullscreen"), GeneralOption::FULLSCREEN },
         { QStringLiteral("input-mouse-support"), GeneralOption::MOUSE_SUPPORT },
         { QStringLiteral("verify-files"), GeneralOption::VERIFY_FILES },
+        { QStringLiteral("scan-on-launch"), GeneralOption::SCAN_ON_LAUNCH },
         { QStringLiteral("show-missing-games"), GeneralOption::SHOW_MISSING_GAMES },
         { QStringLiteral("locale"), GeneralOption::LOCALE },
         { QStringLiteral("theme"), GeneralOption::THEME },
@@ -174,6 +175,10 @@ void LoadContext::handle_general_attrib(const size_t lineno, const QString& key,
             break;
         case ConfigEntryGeneralOption::VERIFY_FILES:
             if (!store_bool_maybe(val, AppSettings::general.verify_files))
+                log_needs_bool(lineno, key);
+            break;
+        case ConfigEntryGeneralOption::SCAN_ON_LAUNCH:
+            if (!store_bool_maybe(val, AppSettings::general.scan_on_launch))
                 log_needs_bool(lineno, key);
             break;
         case ConfigEntryGeneralOption::SHOW_MISSING_GAMES:
@@ -312,6 +317,7 @@ void SaveContext::print_general(QTextStream& stream) const
         { GeneralOption::FULLSCREEN, AppSettings::general.fullscreen ? STR_TRUE : STR_FALSE },
         { GeneralOption::MOUSE_SUPPORT, AppSettings::general.mouse_support ? STR_TRUE : STR_FALSE },
         { GeneralOption::VERIFY_FILES, AppSettings::general.verify_files ? STR_TRUE : STR_FALSE },
+        { GeneralOption::SCAN_ON_LAUNCH, AppSettings::general.scan_on_launch ? STR_TRUE : STR_FALSE },
         { GeneralOption::SHOW_MISSING_GAMES, AppSettings::general.show_missing_games ? STR_TRUE : STR_FALSE },
         { GeneralOption::LOCALE, AppSettings::general.locale },
         { GeneralOption::THEME, theme_path },

--- a/src/backend/parsers/SettingsFile.h
+++ b/src/backend/parsers/SettingsFile.h
@@ -38,6 +38,7 @@ enum class ConfigEntryGeneralOption : unsigned char {
     FULLSCREEN,
     MOUSE_SUPPORT,
     VERIFY_FILES,
+    SCAN_ON_LAUNCH,
     SHOW_MISSING_GAMES,
     LOCALE,
     THEME,

--- a/src/backend/providers/CMakeLists.txt
+++ b/src/backend/providers/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sources(pegasus-backend PRIVATE
     ProviderUtils.h
     SearchContext.cpp
     SearchContext.h
+    GameDataCache.cpp
+    GameDataCache.h
 )
 
 

--- a/src/backend/providers/GameDataCache.cpp
+++ b/src/backend/providers/GameDataCache.cpp
@@ -1,0 +1,387 @@
+// Pegasus Frontend
+// Copyright (C) 2018  Mátyás Mustoha
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "GameDataCache.h"
+
+#include "Log.h"
+#include "Paths.h"
+#include "Provider.h"
+#include "SearchContext.h"
+#include "model/ObjectListModel.h"
+#include "model/gaming/Assets.h"
+#include "model/gaming/Collection.h"
+#include "model/gaming/Game.h"
+#include "model/gaming/GameFile.h"
+#include "types/AssetType.h"
+
+#include <QCryptographicHash>
+#include <QDate>
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QSaveFile>
+#include <QStringList>
+
+namespace {
+constexpr int CACHE_SCHEMA_VERSION = 1;
+
+QJsonArray string_list_to_json(const QStringList& values)
+{
+    QJsonArray out;
+    for (const QString& value : values)
+        out.append(value);
+    return out;
+}
+
+QStringList json_to_string_list(const QJsonValue& value)
+{
+    QStringList out;
+    const QJsonArray array = value.toArray();
+    out.reserve(array.size());
+    for (const QJsonValue& item : array)
+        out.append(item.toString());
+    return out;
+}
+
+QJsonObject assets_to_json(const model::Assets& assets)
+{
+    QJsonObject obj;
+    obj[QStringLiteral("box_front")] = string_list_to_json(assets.boxFrontList());
+    obj[QStringLiteral("box_back")] = string_list_to_json(assets.boxBackList());
+    obj[QStringLiteral("box_spine")] = string_list_to_json(assets.boxSpineList());
+    obj[QStringLiteral("box_full")] = string_list_to_json(assets.boxFullList());
+    obj[QStringLiteral("cartridge")] = string_list_to_json(assets.cartridgeList());
+    obj[QStringLiteral("logo")] = string_list_to_json(assets.logoList());
+    obj[QStringLiteral("poster")] = string_list_to_json(assets.posterList());
+    obj[QStringLiteral("marquee")] = string_list_to_json(assets.marqueeList());
+    obj[QStringLiteral("bezel")] = string_list_to_json(assets.bezelList());
+    obj[QStringLiteral("panel")] = string_list_to_json(assets.panelList());
+    obj[QStringLiteral("cabinet_left")] = string_list_to_json(assets.cabinetLeftList());
+    obj[QStringLiteral("cabinet_right")] = string_list_to_json(assets.cabinetRightList());
+    obj[QStringLiteral("tile")] = string_list_to_json(assets.tileList());
+    obj[QStringLiteral("banner")] = string_list_to_json(assets.bannerList());
+    obj[QStringLiteral("steam")] = string_list_to_json(assets.steamList());
+    obj[QStringLiteral("background")] = string_list_to_json(assets.backgroundList());
+    obj[QStringLiteral("music")] = string_list_to_json(assets.musicList());
+    obj[QStringLiteral("screenshot")] = string_list_to_json(assets.screenshotList());
+    obj[QStringLiteral("titlescreen")] = string_list_to_json(assets.titlescreenList());
+    obj[QStringLiteral("video")] = string_list_to_json(assets.videoList());
+    return obj;
+}
+
+void add_asset_uris(model::Assets& assets, const QJsonObject& obj, const QString& key, const AssetType type)
+{
+    const QStringList values = json_to_string_list(obj.value(key));
+    for (const QString& value : values) {
+        if (!value.isEmpty())
+            assets.add_uri(type, value);
+    }
+}
+
+void assets_from_json(model::Assets& assets, const QJsonValue& value)
+{
+    const QJsonObject obj = value.toObject();
+    add_asset_uris(assets, obj, QStringLiteral("box_front"), AssetType::BOX_FRONT);
+    add_asset_uris(assets, obj, QStringLiteral("box_back"), AssetType::BOX_BACK);
+    add_asset_uris(assets, obj, QStringLiteral("box_spine"), AssetType::BOX_SPINE);
+    add_asset_uris(assets, obj, QStringLiteral("box_full"), AssetType::BOX_FULL);
+    add_asset_uris(assets, obj, QStringLiteral("cartridge"), AssetType::CARTRIDGE);
+    add_asset_uris(assets, obj, QStringLiteral("logo"), AssetType::LOGO);
+    add_asset_uris(assets, obj, QStringLiteral("poster"), AssetType::POSTER);
+    add_asset_uris(assets, obj, QStringLiteral("marquee"), AssetType::ARCADE_MARQUEE);
+    add_asset_uris(assets, obj, QStringLiteral("bezel"), AssetType::ARCADE_BEZEL);
+    add_asset_uris(assets, obj, QStringLiteral("panel"), AssetType::ARCADE_PANEL);
+    add_asset_uris(assets, obj, QStringLiteral("cabinet_left"), AssetType::ARCADE_CABINET_L);
+    add_asset_uris(assets, obj, QStringLiteral("cabinet_right"), AssetType::ARCADE_CABINET_R);
+    add_asset_uris(assets, obj, QStringLiteral("tile"), AssetType::UI_TILE);
+    add_asset_uris(assets, obj, QStringLiteral("banner"), AssetType::UI_BANNER);
+    add_asset_uris(assets, obj, QStringLiteral("steam"), AssetType::UI_STEAMGRID);
+    add_asset_uris(assets, obj, QStringLiteral("background"), AssetType::BACKGROUND);
+    add_asset_uris(assets, obj, QStringLiteral("music"), AssetType::MUSIC);
+    add_asset_uris(assets, obj, QStringLiteral("screenshot"), AssetType::SCREENSHOT);
+    add_asset_uris(assets, obj, QStringLiteral("titlescreen"), AssetType::TITLESCREEN);
+    add_asset_uris(assets, obj, QStringLiteral("video"), AssetType::VIDEO);
+}
+
+void add_file_fingerprint(QJsonArray& out, const QString& path)
+{
+    const QFileInfo fi(path);
+    if (!fi.exists() || !fi.isFile())
+        return;
+
+    QJsonObject item;
+    item[QStringLiteral("path")] = fi.absoluteFilePath();
+    item[QStringLiteral("size")] = QString::number(fi.size());
+    item[QStringLiteral("mtime")] = QString::number(fi.lastModified().toMSecsSinceEpoch());
+    out.append(item);
+}
+
+void add_metadata_fingerprints(QJsonArray& out, const QString& dir_path)
+{
+    const QDir dir(dir_path);
+    if (!dir.exists())
+        return;
+
+    const QStringList names = {
+        QStringLiteral("metadata.pegasus.txt"),
+        QStringLiteral("metadata.txt"),
+    };
+    for (const QString& name : names)
+        add_file_fingerprint(out, dir.absoluteFilePath(name));
+
+    const QStringList filters = {
+        QStringLiteral("*.metadata.pegasus.txt"),
+        QStringLiteral("*.metadata.txt"),
+    };
+    QDirIterator it(dir.absolutePath(), filters, QDir::Files | QDir::NoSymLinks);
+    while (it.hasNext())
+        add_file_fingerprint(out, it.next());
+}
+
+QJsonObject collection_to_json(const model::Collection& collection)
+{
+    QJsonObject obj;
+    obj[QStringLiteral("name")] = collection.name();
+    obj[QStringLiteral("sort_by")] = collection.sortBy();
+    obj[QStringLiteral("short_name")] = collection.shortName();
+    obj[QStringLiteral("summary")] = collection.summary();
+    obj[QStringLiteral("description")] = collection.description();
+    obj[QStringLiteral("common_launch_cmd")] = collection.commonLaunchCmd();
+    obj[QStringLiteral("common_launch_workdir")] = collection.commonLaunchWorkdir();
+    obj[QStringLiteral("common_relative_basedir")] = collection.commonLaunchCmdBasedir();
+    obj[QStringLiteral("assets")] = assets_to_json(collection.assets());
+    return obj;
+}
+
+QJsonObject game_to_json(const model::Game& game)
+{
+    QJsonObject obj;
+    obj[QStringLiteral("title")] = game.title();
+    obj[QStringLiteral("sort_by")] = game.sortBy();
+    obj[QStringLiteral("summary")] = game.summary();
+    obj[QStringLiteral("description")] = game.description();
+    obj[QStringLiteral("developers")] = string_list_to_json(game.developerListConst());
+    obj[QStringLiteral("publishers")] = string_list_to_json(game.publisherListConst());
+    obj[QStringLiteral("genres")] = string_list_to_json(game.genreListConst());
+    obj[QStringLiteral("tags")] = string_list_to_json(game.tagListConst());
+    obj[QStringLiteral("player_count")] = game.playerCount();
+    obj[QStringLiteral("rating")] = game.rating();
+    obj[QStringLiteral("release_date")] = game.releaseDate().toString(Qt::ISODate);
+    obj[QStringLiteral("missing")] = game.isMissing();
+    obj[QStringLiteral("launch_cmd")] = game.launchCmd();
+    obj[QStringLiteral("launch_workdir")] = game.launchWorkdir();
+    obj[QStringLiteral("relative_basedir")] = game.launchCmdBasedir();
+    obj[QStringLiteral("assets")] = assets_to_json(game.assets());
+
+    QJsonArray collection_names;
+    if (game.collectionsModel()) {
+        for (const model::Collection* const collection : game.collectionsModel()->entries()) {
+            if (collection)
+                collection_names.append(collection->name());
+        }
+    }
+    obj[QStringLiteral("collections")] = collection_names;
+
+    QJsonArray files;
+    if (game.filesModel()) {
+        for (const model::GameFile* const file : game.filesModel()->entries()) {
+            if (!file)
+                continue;
+
+            QJsonObject file_obj;
+            file_obj[QStringLiteral("path")] = file->path();
+            file_obj[QStringLiteral("name")] = file->name();
+            file_obj[QStringLiteral("uri")] = file->uri();
+            files.append(file_obj);
+        }
+    }
+    obj[QStringLiteral("files")] = files;
+
+    return obj;
+}
+} // namespace
+
+QString GameDataCache::cacheFilePath()
+{
+    return QDir(paths::writableCacheDir()).absoluteFilePath(QStringLiteral("gameindex-v1.json"));
+}
+
+QString GameDataCache::buildFingerprint(
+    const providers::SearchContext& sctx,
+    const std::vector<providers::Provider*>& providers)
+{
+    QJsonObject root;
+    root[QStringLiteral("schema")] = CACHE_SCHEMA_VERSION;
+
+    QJsonArray provider_names;
+    for (const providers::Provider* provider : providers) {
+        if (provider)
+            provider_names.append(provider->display_name());
+    }
+    root[QStringLiteral("providers")] = provider_names;
+    root[QStringLiteral("root_game_dirs")] = string_list_to_json(sctx.root_game_dirs());
+
+    // Keep the fingerprint based only on inputs that are known before the
+    // providers run. PegasusProvider may populate pegasus_game_dirs() during
+    // scanning, so including it here would make load-time and save-time
+    // fingerprints differ and cause permanent cache misses.
+    QJsonArray metadata_files;
+    for (const QString& dir : paths::configDirs())
+        add_metadata_fingerprints(metadata_files, dir);
+    for (const QString& dir : sctx.root_game_dirs())
+        add_metadata_fingerprints(metadata_files, dir);
+    root[QStringLiteral("metadata_files")] = metadata_files;
+
+    const QJsonDocument doc(root);
+    const QByteArray hash = QCryptographicHash::hash(doc.toJson(QJsonDocument::Compact), QCryptographicHash::Sha256).toHex();
+    return QString::fromLatin1(hash);
+}
+
+bool GameDataCache::load(
+    providers::SearchContext& sctx,
+    const std::vector<providers::Provider*>& providers)
+{
+    const QString expected_fingerprint = buildFingerprint(sctx, providers);
+    QFile file(cacheFilePath());
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    const QJsonObject root = doc.object();
+    if (root.value(QStringLiteral("schema")).toInt() != CACHE_SCHEMA_VERSION)
+        return false;
+    if (root.value(QStringLiteral("fingerprint")).toString() != expected_fingerprint)
+        return false;
+
+    const QJsonArray collections = root.value(QStringLiteral("collections")).toArray();
+    for (const QJsonValue& value : collections) {
+        const QJsonObject obj = value.toObject();
+        const QString name = obj.value(QStringLiteral("name")).toString();
+        if (name.isEmpty())
+            continue;
+
+        model::Collection* collection = sctx.get_or_create_collection(name);
+        collection->setSortBy(obj.value(QStringLiteral("sort_by")).toString());
+        collection->setShortName(obj.value(QStringLiteral("short_name")).toString());
+        collection->setSummary(obj.value(QStringLiteral("summary")).toString());
+        collection->setDescription(obj.value(QStringLiteral("description")).toString());
+        collection->setCommonLaunchCmd(obj.value(QStringLiteral("common_launch_cmd")).toString());
+        collection->setCommonLaunchWorkdir(obj.value(QStringLiteral("common_launch_workdir")).toString());
+        collection->setCommonLaunchCmdBasedir(obj.value(QStringLiteral("common_relative_basedir")).toString());
+        assets_from_json(collection->assetsMut(), obj.value(QStringLiteral("assets")));
+    }
+
+    const QJsonArray games = root.value(QStringLiteral("games")).toArray();
+    for (const QJsonValue& value : games) {
+        const QJsonObject obj = value.toObject();
+        const QString title = obj.value(QStringLiteral("title")).toString();
+        if (title.isEmpty())
+            continue;
+
+        model::Game* game = sctx.create_game();
+        game->setTitle(title);
+        game->setSortBy(obj.value(QStringLiteral("sort_by")).toString());
+        game->setSummary(obj.value(QStringLiteral("summary")).toString());
+        game->setDescription(obj.value(QStringLiteral("description")).toString());
+        game->developerList().append(json_to_string_list(obj.value(QStringLiteral("developers"))));
+        game->publisherList().append(json_to_string_list(obj.value(QStringLiteral("publishers"))));
+        game->genreList().append(json_to_string_list(obj.value(QStringLiteral("genres"))));
+        game->tagList().append(json_to_string_list(obj.value(QStringLiteral("tags"))));
+        game->setPlayerCount(obj.value(QStringLiteral("player_count")).toInt(1));
+        game->setRating(static_cast<float>(obj.value(QStringLiteral("rating")).toDouble(0.0)));
+        game->setReleaseDate(QDate::fromString(obj.value(QStringLiteral("release_date")).toString(), Qt::ISODate));
+        game->setMissing(obj.value(QStringLiteral("missing")).toBool(false));
+        game->setLaunchCmd(obj.value(QStringLiteral("launch_cmd")).toString());
+        game->setLaunchWorkdir(obj.value(QStringLiteral("launch_workdir")).toString());
+        game->setLaunchCmdBasedir(obj.value(QStringLiteral("relative_basedir")).toString());
+        assets_from_json(game->assetsMut(), obj.value(QStringLiteral("assets")));
+
+        const QStringList collection_names = json_to_string_list(obj.value(QStringLiteral("collections")));
+        for (const QString& collection_name : collection_names) {
+            if (collection_name.isEmpty())
+                continue;
+            model::Collection* collection = sctx.get_or_create_collection(collection_name);
+            sctx.game_add_to(*game, *collection);
+        }
+
+        const QJsonArray files = obj.value(QStringLiteral("files")).toArray();
+        for (const QJsonValue& file_value : files) {
+            const QJsonObject file_obj = file_value.toObject();
+            const QString uri = file_obj.value(QStringLiteral("uri")).toString();
+            const QString path = file_obj.value(QStringLiteral("path")).toString();
+            model::GameFile* game_file = nullptr;
+            if (!path.isEmpty())
+                game_file = sctx.game_add_filepath(*game, path);
+            else if (!uri.isEmpty())
+                game_file = sctx.game_add_uri(*game, uri);
+
+            if (game_file)
+                game_file->setName(file_obj.value(QStringLiteral("name")).toString());
+        }
+    }
+
+    Log::info(LOGMSG("Loaded game index cache"));
+    return true;
+}
+
+void GameDataCache::save(
+    const providers::SearchContext& sctx,
+    const std::vector<providers::Provider*>& providers,
+    const std::vector<model::Collection*>& collections,
+    const std::vector<model::Game*>& games)
+{
+    QJsonObject root;
+    root[QStringLiteral("schema")] = CACHE_SCHEMA_VERSION;
+    root[QStringLiteral("fingerprint")] = buildFingerprint(sctx, providers);
+
+    QJsonArray collection_array;
+    for (const model::Collection* collection : collections) {
+        if (collection)
+            collection_array.append(collection_to_json(*collection));
+    }
+    root[QStringLiteral("collections")] = collection_array;
+
+    QJsonArray game_array;
+    for (const model::Game* game : games) {
+        if (game)
+            game_array.append(game_to_json(*game));
+    }
+    root[QStringLiteral("games")] = game_array;
+
+    QDir().mkpath(paths::writableCacheDir());
+    QSaveFile file(cacheFilePath());
+    if (!file.open(QIODevice::WriteOnly)) {
+        Log::warning(LOGMSG("Could not open game index cache for writing"));
+        return;
+    }
+
+    file.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+    if (!file.commit())
+        Log::warning(LOGMSG("Could not write game index cache"));
+    else
+        Log::info(LOGMSG("Saved game index cache"));
+}
+
+void GameDataCache::clear()
+{
+    QFile::remove(cacheFilePath());
+}

--- a/src/backend/providers/GameDataCache.cpp
+++ b/src/backend/providers/GameDataCache.cpp
@@ -52,6 +52,12 @@ QJsonArray string_list_to_json(const QStringList& values)
     return out;
 }
 
+void add_non_empty_array(QJsonObject& obj, const QString& key, const QJsonArray& values)
+{
+    if (!values.isEmpty())
+        obj[key] = values;
+}
+
 QStringList json_to_string_list(const QJsonValue& value)
 {
     QStringList out;
@@ -65,26 +71,26 @@ QStringList json_to_string_list(const QJsonValue& value)
 QJsonObject assets_to_json(const model::Assets& assets)
 {
     QJsonObject obj;
-    obj[QStringLiteral("box_front")] = string_list_to_json(assets.boxFrontList());
-    obj[QStringLiteral("box_back")] = string_list_to_json(assets.boxBackList());
-    obj[QStringLiteral("box_spine")] = string_list_to_json(assets.boxSpineList());
-    obj[QStringLiteral("box_full")] = string_list_to_json(assets.boxFullList());
-    obj[QStringLiteral("cartridge")] = string_list_to_json(assets.cartridgeList());
-    obj[QStringLiteral("logo")] = string_list_to_json(assets.logoList());
-    obj[QStringLiteral("poster")] = string_list_to_json(assets.posterList());
-    obj[QStringLiteral("marquee")] = string_list_to_json(assets.marqueeList());
-    obj[QStringLiteral("bezel")] = string_list_to_json(assets.bezelList());
-    obj[QStringLiteral("panel")] = string_list_to_json(assets.panelList());
-    obj[QStringLiteral("cabinet_left")] = string_list_to_json(assets.cabinetLeftList());
-    obj[QStringLiteral("cabinet_right")] = string_list_to_json(assets.cabinetRightList());
-    obj[QStringLiteral("tile")] = string_list_to_json(assets.tileList());
-    obj[QStringLiteral("banner")] = string_list_to_json(assets.bannerList());
-    obj[QStringLiteral("steam")] = string_list_to_json(assets.steamList());
-    obj[QStringLiteral("background")] = string_list_to_json(assets.backgroundList());
-    obj[QStringLiteral("music")] = string_list_to_json(assets.musicList());
-    obj[QStringLiteral("screenshot")] = string_list_to_json(assets.screenshotList());
-    obj[QStringLiteral("titlescreen")] = string_list_to_json(assets.titlescreenList());
-    obj[QStringLiteral("video")] = string_list_to_json(assets.videoList());
+    add_non_empty_array(obj, QStringLiteral("box_front"), string_list_to_json(assets.boxFrontList()));
+    add_non_empty_array(obj, QStringLiteral("box_back"), string_list_to_json(assets.boxBackList()));
+    add_non_empty_array(obj, QStringLiteral("box_spine"), string_list_to_json(assets.boxSpineList()));
+    add_non_empty_array(obj, QStringLiteral("box_full"), string_list_to_json(assets.boxFullList()));
+    add_non_empty_array(obj, QStringLiteral("cartridge"), string_list_to_json(assets.cartridgeList()));
+    add_non_empty_array(obj, QStringLiteral("logo"), string_list_to_json(assets.logoList()));
+    add_non_empty_array(obj, QStringLiteral("poster"), string_list_to_json(assets.posterList()));
+    add_non_empty_array(obj, QStringLiteral("marquee"), string_list_to_json(assets.marqueeList()));
+    add_non_empty_array(obj, QStringLiteral("bezel"), string_list_to_json(assets.bezelList()));
+    add_non_empty_array(obj, QStringLiteral("panel"), string_list_to_json(assets.panelList()));
+    add_non_empty_array(obj, QStringLiteral("cabinet_left"), string_list_to_json(assets.cabinetLeftList()));
+    add_non_empty_array(obj, QStringLiteral("cabinet_right"), string_list_to_json(assets.cabinetRightList()));
+    add_non_empty_array(obj, QStringLiteral("tile"), string_list_to_json(assets.tileList()));
+    add_non_empty_array(obj, QStringLiteral("banner"), string_list_to_json(assets.bannerList()));
+    add_non_empty_array(obj, QStringLiteral("steam"), string_list_to_json(assets.steamList()));
+    add_non_empty_array(obj, QStringLiteral("background"), string_list_to_json(assets.backgroundList()));
+    add_non_empty_array(obj, QStringLiteral("music"), string_list_to_json(assets.musicList()));
+    add_non_empty_array(obj, QStringLiteral("screenshot"), string_list_to_json(assets.screenshotList()));
+    add_non_empty_array(obj, QStringLiteral("titlescreen"), string_list_to_json(assets.titlescreenList()));
+    add_non_empty_array(obj, QStringLiteral("video"), string_list_to_json(assets.videoList()));
     return obj;
 }
 
@@ -179,10 +185,10 @@ QJsonObject game_to_json(const model::Game& game)
     obj[QStringLiteral("sort_by")] = game.sortBy();
     obj[QStringLiteral("summary")] = game.summary();
     obj[QStringLiteral("description")] = game.description();
-    obj[QStringLiteral("developers")] = string_list_to_json(game.developerListConst());
-    obj[QStringLiteral("publishers")] = string_list_to_json(game.publisherListConst());
-    obj[QStringLiteral("genres")] = string_list_to_json(game.genreListConst());
-    obj[QStringLiteral("tags")] = string_list_to_json(game.tagListConst());
+    add_non_empty_array(obj, QStringLiteral("developers"), string_list_to_json(game.developerListConst()));
+    add_non_empty_array(obj, QStringLiteral("publishers"), string_list_to_json(game.publisherListConst()));
+    add_non_empty_array(obj, QStringLiteral("genres"), string_list_to_json(game.genreListConst()));
+    add_non_empty_array(obj, QStringLiteral("tags"), string_list_to_json(game.tagListConst()));
     obj[QStringLiteral("player_count")] = game.playerCount();
     obj[QStringLiteral("rating")] = game.rating();
     obj[QStringLiteral("release_date")] = game.releaseDate().toString(Qt::ISODate);
@@ -199,7 +205,7 @@ QJsonObject game_to_json(const model::Game& game)
                 collection_names.append(collection->name());
         }
     }
-    obj[QStringLiteral("collections")] = collection_names;
+    add_non_empty_array(obj, QStringLiteral("collections"), collection_names);
 
     QJsonArray files;
     if (game.filesModel()) {
@@ -214,7 +220,7 @@ QJsonObject game_to_json(const model::Game& game)
             files.append(file_obj);
         }
     }
-    obj[QStringLiteral("files")] = files;
+    add_non_empty_array(obj, QStringLiteral("files"), files);
 
     return obj;
 }
@@ -360,14 +366,14 @@ void GameDataCache::save(
         if (collection)
             collection_array.append(collection_to_json(*collection));
     }
-    root[QStringLiteral("collections")] = collection_array;
+    add_non_empty_array(root, QStringLiteral("collections"), collection_array);
 
     QJsonArray game_array;
     for (const model::Game* game : games) {
         if (game)
             game_array.append(game_to_json(*game));
     }
-    root[QStringLiteral("games")] = game_array;
+    add_non_empty_array(root, QStringLiteral("games"), game_array);
 
     QDir().mkpath(paths::writableCacheDir());
     QSaveFile file(cacheFilePath());

--- a/src/backend/providers/GameDataCache.cpp
+++ b/src/backend/providers/GameDataCache.cpp
@@ -232,12 +232,12 @@ QString GameDataCache::buildFingerprint(
     QJsonObject root;
     root[QStringLiteral("schema")] = CACHE_SCHEMA_VERSION;
 
-    QJsonArray provider_names;
+    QJsonArray provider_ids;
     for (const providers::Provider* provider : providers) {
         if (provider)
-            provider_names.append(provider->display_name());
+            provider_ids.append(QString(provider->codename()));
     }
-    root[QStringLiteral("providers")] = provider_names;
+    root[QStringLiteral("providers")] = provider_ids;
     root[QStringLiteral("root_game_dirs")] = string_list_to_json(sctx.root_game_dirs());
 
     // Keep the fingerprint based only on inputs that are known before the
@@ -269,8 +269,10 @@ bool GameDataCache::load(
     const QJsonObject root = doc.object();
     if (root.value(QStringLiteral("schema")).toInt() != CACHE_SCHEMA_VERSION)
         return false;
-    if (root.value(QStringLiteral("fingerprint")).toString() != expected_fingerprint)
+    if (root.value(QStringLiteral("fingerprint")).toString() != expected_fingerprint){
+        Log::info(LOGMSG("Ignoring game index cache: fingerprint mismatch"));
         return false;
+    }
 
     const QJsonArray collections = root.value(QStringLiteral("collections")).toArray();
     for (const QJsonValue& value : collections) {

--- a/src/backend/providers/GameDataCache.h
+++ b/src/backend/providers/GameDataCache.h
@@ -1,0 +1,53 @@
+// Pegasus Frontend
+// Copyright (C) 2017-2019  Mátyás Mustoha
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <vector>
+
+namespace model {
+class Collection;
+class Game;
+}
+
+namespace providers {
+class Provider;
+class SearchContext;
+}
+
+class GameDataCache {
+public:
+    static bool load(
+        providers::SearchContext&,
+        const std::vector<providers::Provider*>&);
+
+    static void save(
+        const providers::SearchContext&,
+        const std::vector<providers::Provider*>&,
+        const std::vector<model::Collection*>&,
+        const std::vector<model::Game*>&);
+
+    static void clear();
+
+private:
+    static QString cacheFilePath();
+    static QString buildFingerprint(
+        const providers::SearchContext&,
+        const std::vector<providers::Provider*>&);
+};

--- a/src/backend/providers/Provider.h
+++ b/src/backend/providers/Provider.h
@@ -35,6 +35,7 @@ namespace providers {
 constexpr uint8_t PROVIDER_FLAG_NONE = 0;
 constexpr uint8_t PROVIDER_FLAG_INTERNAL = (1 << 0);
 constexpr uint8_t PROVIDER_FLAG_HIDE_PROGRESS = (1 << 1);
+constexpr uint8_t PROVIDER_FLAG_CACHEABLE = (1 << 2);
 
 
 class Provider : public QObject {

--- a/src/backend/providers/ProviderManager.cpp
+++ b/src/backend/providers/ProviderManager.cpp
@@ -50,7 +50,7 @@ ProviderManager::ProviderManager(QObject* parent)
     }
 }
 
-void ProviderManager::run(bool force_refresh)
+void ProviderManager::run(const bool force_refresh)
 {
     Q_ASSERT(!m_future.isRunning());
 

--- a/src/backend/providers/ProviderManager.cpp
+++ b/src/backend/providers/ProviderManager.cpp
@@ -18,6 +18,7 @@
 #include "ProviderManager.h"
 
 #include "AppSettings.h"
+#include "GameDataCache.h"
 #include "Log.h"
 #include "Provider.h"
 #include "SearchContext.h"
@@ -62,12 +63,35 @@ void ProviderManager::run()
         providers::SearchContext sctx;
         sctx.enable_network();
 
-
         QElapsedTimer run_timer;
         run_timer.start();
 
         const std::vector<ProviderPtr> providers = enabled_providers();
+        if (GameDataCache::load(sctx, providers)) {
+            for (const ProviderPtr& provider : providers) {
+                const QString provider_name = provider->display_name().toLower();
+                if (!provider_name.contains(QStringLiteral("favorite"))
+                    && !provider_name.contains(QStringLiteral("playtime")))
+                    continue;
 
+                Log::info(LOGMSG("Running lightweight provider after cache restore: %1")
+                    .arg(provider->display_name()));
+                provider->run(sctx);
+            }
+
+            QElapsedTimer finalize_timer;
+            finalize_timer.start();
+            // TODO: C++17
+            std::tie(m_found_collections, m_found_games) = sctx.finalize();
+            Log::info(LOGMSG("Game list cache restore took %1ms").arg(finalize_timer.elapsed()));
+
+            m_current_progress = 1.f;
+            m_current_stage = QString();
+            emit scanProgressChanged(m_current_progress, m_current_stage);
+            emit scanFinished();
+            return;
+        }
+        
         size_t progress_sections = providers.size();
         for (const ProviderPtr provider : providers) {
             if (provider->flags() & providers::PROVIDER_FLAG_HIDE_PROGRESS)
@@ -122,6 +146,7 @@ void ProviderManager::run()
         std::tie(m_found_collections, m_found_games) = sctx.finalize();
 
         Log::info(LOGMSG("Game list post-processing took %1ms").arg(finalize_timer.elapsed()));
+        GameDataCache::save(sctx, providers, m_found_collections, m_found_games);
         emit scanFinished();
     });
 }

--- a/src/backend/providers/ProviderManager.cpp
+++ b/src/backend/providers/ProviderManager.cpp
@@ -50,7 +50,7 @@ ProviderManager::ProviderManager(QObject* parent)
     }
 }
 
-void ProviderManager::run(bool force_refresh);
+void ProviderManager::run(bool force_refresh)
 {
     Q_ASSERT(!m_future.isRunning());
 

--- a/src/backend/providers/ProviderManager.cpp
+++ b/src/backend/providers/ProviderManager.cpp
@@ -68,14 +68,11 @@ void ProviderManager::run(const bool force_refresh)
 
         const std::vector<ProviderPtr> providers = enabled_providers();
 
-        if (force_refresh)
-            Log::info(LOGMSG("Bypassing game index cache due to forced refresh"));
-
         if (!force_refresh && GameDataCache::load(sctx, providers)) {
+            Log::info(LOGMSG("Skipping full scan due to game index cache"));
+
             for (const ProviderPtr& provider : providers) {
-                const QString provider_name = provider->display_name().toLower();
-                if (!provider_name.contains(QStringLiteral("favorite"))
-                    && !provider_name.contains(QStringLiteral("playtime")))
+                if (provider->flags() & providers::PROVIDER_FLAG_CACHEABLE)
                     continue;
 
                 Log::info(LOGMSG("Running lightweight provider after cache restore: %1")

--- a/src/backend/providers/ProviderManager.cpp
+++ b/src/backend/providers/ProviderManager.cpp
@@ -50,14 +50,14 @@ ProviderManager::ProviderManager(QObject* parent)
     }
 }
 
-void ProviderManager::run()
+void ProviderManager::run(bool force_refresh);
 {
     Q_ASSERT(!m_future.isRunning());
 
     m_found_games.clear();
     m_found_collections.clear();
 
-    m_future = QtConcurrent::run([this]{
+    m_future = QtConcurrent::run([this, force_refresh]{
         emit scanStarted();
 
         providers::SearchContext sctx;
@@ -67,7 +67,11 @@ void ProviderManager::run()
         run_timer.start();
 
         const std::vector<ProviderPtr> providers = enabled_providers();
-        if (GameDataCache::load(sctx, providers)) {
+
+        if (force_refresh)
+            Log::info(LOGMSG("Bypassing game index cache due to forced refresh"));
+
+        if (!force_refresh && GameDataCache::load(sctx, providers)) {
             for (const ProviderPtr& provider : providers) {
                 const QString provider_name = provider->display_name().toLower();
                 if (!provider_name.contains(QStringLiteral("favorite"))

--- a/src/backend/providers/ProviderManager.h
+++ b/src/backend/providers/ProviderManager.h
@@ -31,7 +31,7 @@ class ProviderManager : public QObject {
 public:
     explicit ProviderManager(QObject* parent = nullptr);
 
-    void run(bool force_refresh = false);
+    void run(const bool force_refresh);
 
     void onGameLaunched(model::GameFile* const) const;
     void onGameFinished(model::GameFile* const) const;

--- a/src/backend/providers/ProviderManager.h
+++ b/src/backend/providers/ProviderManager.h
@@ -31,7 +31,7 @@ class ProviderManager : public QObject {
 public:
     explicit ProviderManager(QObject* parent = nullptr);
 
-    void run();
+    void run(bool force_refresh = false);
 
     void onGameLaunched(model::GameFile* const) const;
     void onGameFinished(model::GameFile* const) const;

--- a/src/backend/providers/android_apps/AndroidAppsProvider.cpp
+++ b/src/backend/providers/android_apps/AndroidAppsProvider.cpp
@@ -123,7 +123,7 @@ namespace providers {
 namespace android {
 
 AndroidAppsProvider::AndroidAppsProvider(QObject* parent)
-    : Provider(QLatin1String("androidapps"), QStringLiteral("Android Apps"), parent)
+    : Provider(QLatin1String("androidapps"), QStringLiteral("Android Apps"), PROVIDER_FLAG_CACHEABLE, parent)
     , m_metahelper(display_name())
 {}
 

--- a/src/backend/providers/es2/Es2Provider.cpp
+++ b/src/backend/providers/es2/Es2Provider.cpp
@@ -42,7 +42,7 @@ namespace providers {
 namespace es2 {
 
 Es2Provider::Es2Provider(QObject* parent)
-    : Provider(QLatin1String("es2"), QStringLiteral("EmulationStation"), parent)
+    : Provider(QLatin1String("es2"), QStringLiteral("EmulationStation"), PROVIDER_FLAG_CACHEABLE, parent)
 {}
 
 Provider& Es2Provider::run(SearchContext& sctx)

--- a/src/backend/providers/gog/GogProvider.cpp
+++ b/src/backend/providers/gog/GogProvider.cpp
@@ -70,7 +70,7 @@ namespace providers {
 namespace gog {
 
 GogProvider::GogProvider(QObject* parent)
-    : Provider(QLatin1String("gog"), QStringLiteral("GOG"), parent)
+    : Provider(QLatin1String("gog"), QStringLiteral("GOG"), PROVIDER_FLAG_CACHEABLE, parent)
 {}
 
 Provider& GogProvider::run(SearchContext& sctx)

--- a/src/backend/providers/launchbox/LaunchBoxProvider.cpp
+++ b/src/backend/providers/launchbox/LaunchBoxProvider.cpp
@@ -40,7 +40,7 @@ namespace providers {
 namespace launchbox {
 
 LaunchboxProvider::LaunchboxProvider(QObject* parent)
-    : Provider(QLatin1String("launchbox"), QStringLiteral("LaunchBox"), parent)
+    : Provider(QLatin1String("launchbox"), QStringLiteral("LaunchBox"), PROVIDER_FLAG_CACHEABLE, parent)
 {}
 
 Provider& LaunchboxProvider::run(providers::SearchContext& sctx)

--- a/src/backend/providers/logiqx/LogiqxProvider.cpp
+++ b/src/backend/providers/logiqx/LogiqxProvider.cpp
@@ -261,7 +261,7 @@ namespace providers {
 namespace logiqx {
 
 LogiqxProvider::LogiqxProvider(QObject* parent)
-    : Provider(QLatin1String("logiqx"), QStringLiteral("Logiqx"), parent)
+    : Provider(QLatin1String("logiqx"), QStringLiteral("Logiqx"), PROVIDER_FLAG_CACHEABLE, parent)
 {}
 
 

--- a/src/backend/providers/lutris/LutrisProvider.cpp
+++ b/src/backend/providers/lutris/LutrisProvider.cpp
@@ -112,7 +112,7 @@ namespace providers {
 namespace lutris {
 
 LutrisProvider::LutrisProvider(QObject* parent)
-    : Provider(QLatin1String("lutris"), QStringLiteral("Lutris"), parent)
+    : Provider(QLatin1String("lutris"), QStringLiteral("Lutris"), PROVIDER_FLAG_CACHEABLE, parent)
 {}
 
 Provider& LutrisProvider::run(SearchContext& sctx)

--- a/src/backend/providers/pegasus_media/MediaProvider.cpp
+++ b/src/backend/providers/pegasus_media/MediaProvider.cpp
@@ -88,7 +88,7 @@ namespace providers {
 namespace media {
 
 MediaProvider::MediaProvider(QObject* parent)
-    : Provider(QLatin1String("pegasus_media"), QStringLiteral("Pegasus Media"), parent)
+    : Provider(QLatin1String("pegasus_media"), QStringLiteral("Pegasus Media"), PROVIDER_FLAG_CACHEABLE, parent)
 {}
 
 Provider& MediaProvider::run(SearchContext& sctx)

--- a/src/backend/providers/pegasus_metadata/PegasusProvider.cpp
+++ b/src/backend/providers/pegasus_metadata/PegasusProvider.cpp
@@ -79,7 +79,7 @@ namespace providers {
 namespace pegasus {
 
 PegasusProvider::PegasusProvider(QObject* parent)
-    : Provider(QLatin1String("pegasus_metafiles"), QStringLiteral("Pegasus Metafiles"), PROVIDER_FLAG_INTERNAL, parent)
+    : Provider(QLatin1String("pegasus_metafiles"), QStringLiteral("Pegasus Metafiles"), PROVIDER_FLAG_INTERNAL | PROVIDER_FLAG_CACHEABLE, parent)
 {}
 
 Provider& PegasusProvider::run(SearchContext& sctx)

--- a/src/backend/providers/playnite/PlayniteProvider.cpp
+++ b/src/backend/providers/playnite/PlayniteProvider.cpp
@@ -129,7 +129,7 @@ void apply_game_fields(
 } // namespace
 
 PlayniteProvider::PlayniteProvider(QObject* parent)
-    : Provider(QLatin1String("playnite"), QStringLiteral("Playnite"), parent)
+    : Provider(QLatin1String("playnite"), QStringLiteral("Playnite"), PROVIDER_FLAG_CACHEABLE, parent)
 {}
 
 Provider& PlayniteProvider::run(SearchContext& sctx)

--- a/src/backend/providers/providers.pri
+++ b/src/backend/providers/providers.pri
@@ -3,12 +3,14 @@ HEADERS += \
     $$PWD/ProviderManager.h \
     $$PWD/ProviderUtils.h \
     $$PWD/SearchContext.h \
+    $$PWD/GameDataCache.h \
 
 SOURCES += \
     $$PWD/Provider.cpp \
     $$PWD/ProviderManager.cpp \
     $$PWD/ProviderUtils.cpp \
     $$PWD/SearchContext.cpp \
+    $$PWD/GameDataCache.cpp \
 
 include(pegasus_favorites/pegasus_favorites.pri)
 include(pegasus_metadata/pegasus_metadata.pri)

--- a/src/backend/providers/skraper/SkraperAssetsProvider.cpp
+++ b/src/backend/providers/skraper/SkraperAssetsProvider.cpp
@@ -50,7 +50,7 @@ namespace providers {
 namespace skraper {
 
 SkraperAssetsProvider::SkraperAssetsProvider(QObject* parent)
-    : Provider(QLatin1String("skraper"), QStringLiteral("Skraper Assets"), parent)
+    : Provider(QLatin1String("skraper"), QStringLiteral("Skraper Assets"), PROVIDER_FLAG_CACHEABLE, parent)
 {}
 
 Provider& SkraperAssetsProvider::run(SearchContext& sctx)

--- a/src/backend/providers/steam/SteamProvider.cpp
+++ b/src/backend/providers/steam/SteamProvider.cpp
@@ -171,7 +171,7 @@ namespace providers {
 namespace steam {
 
 SteamProvider::SteamProvider(QObject* parent)
-    : Provider(QLatin1String("steam"), QStringLiteral("Steam"), parent)
+    : Provider(QLatin1String("steam"), QStringLiteral("Steam"), PROVIDER_FLAG_CACHEABLE, parent)
 {}
 
 Provider& SteamProvider::run(SearchContext& sctx)

--- a/src/frontend/menu/settings/SettingsMain.qml
+++ b/src/frontend/menu/settings/SettingsMain.qml
@@ -125,7 +125,7 @@ FocusScope {
         },
         SettingsEntry {
             label: QT_TR_NOOP("Scan for games on launch")
-            desc: QT_TR_NOOP("Scan for games every time Pegasus starts. Disable this to restore the previous game list from cache; manually reload after making library changes.")
+            desc: QT_TR_NOOP("Scan for games every time Pegasus starts. You can disable this to improve loading times, but you will need to manually reload the game list to pick up changes.")
             type: SettingsEntry.Type.Bool
             boolValue: Internal.settings.scanOnLaunch
             boolSetter: (val) => Internal.settings.scanOnLaunch = val

--- a/src/frontend/menu/settings/SettingsMain.qml
+++ b/src/frontend/menu/settings/SettingsMain.qml
@@ -124,6 +124,14 @@ FocusScope {
             enabled: Qt.platform.os === "android"
         },
         SettingsEntry {
+            label: QT_TR_NOOP("Scan for games on launch")
+            desc: QT_TR_NOOP("Scan for games every time Pegasus starts. Disable this to restore the previous game list from cache; manually reload after making library changes.")
+            type: SettingsEntry.Type.Bool
+            boolValue: Internal.settings.scanOnLaunch
+            boolSetter: (val) => Internal.settings.scanOnLaunch = val
+            section: "gaming"
+        },
+        SettingsEntry {
             label: QT_TR_NOOP("Validate game files")
             desc: QT_TR_NOOP("Check the game files and only show games that actually exist. You can disable this to improve loading times.")
             type: SettingsEntry.Type.Bool


### PR DESCRIPTION
Adds a lightweight game metadata cache to speed up startup with large libraries.

### Cache invalidation

The cache is automatically invalidated when:

- metadata files change (`metadata.txt`, `metadata.pegasus.txt`, `*.metadata.txt`, `*.metadata.pegasus.txt`)
- enabled providers change
- cache schema version changes

The cache is intended to speed up repeated launches of an unchanged library.

Changes to ROM files or media assets without corresponding metadata changes currently require a manual refresh/reload.

### Testing

Tested on Android 15 (Odin3) with a large ROM collection (~1TB).

Verified:

- initial scan creates cache successfully
- subsequent launches restore from cache
- favorites persist correctly after cache restoration
- metadata modifications invalidate the cache and trigger a full rescan