### PR TITLE
add game slugs and playtime support for them

### DIFF
--- a/src/backend/model/gaming/Game.cpp
+++ b/src/backend/model/gaming/Game.cpp
@@ -90,7 +90,10 @@ void Game::onEntryPlayStatsChanged()
     const auto prev_play_time = m_data.playstats.play_time;
     const auto prev_last_played = m_data.playstats.last_played;
 
-    Q_ASSERT(filesModel());
+    // this is null if called inside PlaytimeStats::run
+    if (filesModel() == nullptr) 
+        return;
+
     const std::vector<model::GameFile*>& filelist = filesModel()->entries();
 
     m_data.playstats.play_count = std::accumulate(filelist.cbegin(), filelist.cend(), 0,
@@ -105,6 +108,10 @@ void Game::onEntryPlayStatsChanged()
         [](const QDateTime& current_max, const model::GameFile* const gamefile){
             return std::max(current_max, gamefile->lastPlayed());
         });
+
+    m_data.playstats.play_count += m_data.playstats_self.play_count;
+    m_data.playstats.play_time += m_data.playstats_self.play_time;
+    m_data.playstats.last_played = std::max(m_data.playstats.last_played, m_data.playstats_self.last_played);
 
     const bool changed = prev_play_count != m_data.playstats.play_count
         || prev_play_time != m_data.playstats.play_time
@@ -121,6 +128,14 @@ void Game::launch()
         m_files->entries().front()->launch();
     else
         emit launchFileSelectorRequested();
+}
+
+void Game::update_playstats(int playcount, qint64 playtime, QDateTime last_played)
+{
+    m_data.playstats_self.last_played = std::max(m_data.playstats_self.last_played, std::move(last_played));
+    m_data.playstats_self.play_time += playtime;
+    m_data.playstats_self.play_count += playcount;
+    onEntryPlayStatsChanged();
 }
 
 Game& Game::setFiles(std::vector<model::GameFile*>&& files)

--- a/src/backend/model/gaming/Game.h
+++ b/src/backend/model/gaming/Game.h
@@ -43,6 +43,7 @@ struct GameData {
     QString sort_by;
     QString summary;
     QString description;
+    QString slug;
 
     QStringList developers;
     QStringList publishers;
@@ -58,6 +59,9 @@ struct GameData {
         int play_time = 0;
         QDateTime last_played;
     } playstats;
+
+    // playstats tied to the game itself and not a specific file
+    PlayStats playstats_self;
 
     bool is_favorite = false;
     bool missing = false;
@@ -81,6 +85,8 @@ public:
     GETTER(const QString&, sortBy, sort_by)
     GETTER(const QString&, summary, summary)
     GETTER(const QString&, description, description)
+    GETTER(const QString&, slug, slug)
+    bool hasSlug() const { return !m_data.slug.isEmpty(); }
     GETTER(const QDate&, releaseDate, release_date)
     GETTER(int, playerCount, player_count)
     GETTER(float, rating, rating)
@@ -113,6 +119,7 @@ public:
     SETTER(QString, SortBy, sort_by)
     SETTER(QString, Summary, summary)
     SETTER(QString, Description, description)
+    SETTER(QString, Slug, slug)
     SETTER(QDate, ReleaseDate, release_date)
 
     SETTER(QString, LaunchCmd, launch_params.launch_cmd)
@@ -144,6 +151,7 @@ public:
     Q_PROPERTY(QString sortBy READ sortBy CONSTANT)
     Q_PROPERTY(QString summary READ summary CONSTANT)
     Q_PROPERTY(QString description READ description CONSTANT)
+    Q_PROPERTY(QString slug READ slug CONSTANT)
     Q_PROPERTY(QDate release READ releaseDate CONSTANT)
     Q_PROPERTY(int players READ playerCount CONSTANT)
     Q_PROPERTY(float rating READ rating CONSTANT)
@@ -201,6 +209,7 @@ public:
     explicit Game(QString name, QObject* parent = nullptr);
 
     Q_INVOKABLE void launch();
+    void update_playstats(int playcount, qint64 playtime, QDateTime last_played);
 
     void finalize();
 };

--- a/src/backend/model/gaming/Game.h
+++ b/src/backend/model/gaming/Game.h
@@ -86,7 +86,6 @@ public:
     GETTER(const QString&, summary, summary)
     GETTER(const QString&, description, description)
     GETTER(const QString&, slug, slug)
-    bool hasSlug() const { return !m_data.slug.isEmpty(); }
     GETTER(const QDate&, releaseDate, release_date)
     GETTER(int, playerCount, player_count)
     GETTER(float, rating, rating)
@@ -171,6 +170,8 @@ public:
     QVariantMap& extraMapMut() { return m_extra; }
 
 
+    bool hasSlug() const { return !m_data.slug.isEmpty(); }
+    
     const Assets& assets() const { return *m_assets; }
     Assets& assetsMut() { return *m_assets; }
     Assets* assetsPtr() const { return m_assets; }

--- a/src/backend/providers/SearchContext.cpp
+++ b/src/backend/providers/SearchContext.cpp
@@ -98,6 +98,15 @@ model::Game* SearchContext::create_game()
     return game_ptr;
 }
 
+std::vector<model::Game*> SearchContext::games_by_slug(const QString& slug) const
+{
+    std::vector<model::Game*> found_games;
+    for (const auto& pair : m_game_entries) {
+        if (pair.first->slug() == slug) found_games.emplace_back(pair.first);
+    }
+    return found_games;
+}
+
 model::Game* SearchContext::game_by_filepath(const QString& can_path) const
 {
     model::GameFile* const entry_ptr = gamefile_by_filepath(can_path);
@@ -249,7 +258,7 @@ void SearchContext::finalize_apply_lists()
     for (auto& pair : m_collection_games) {
         VEC_REMOVE_DUPLICATES(pair.second);
         pair.first->setGames(std::move(pair.second));
-    }
+    } 
 }
 
 std::pair<std::vector<model::Collection*>, std::vector<model::Game*>> SearchContext::finalize(QObject* const parent)

--- a/src/backend/providers/SearchContext.cpp
+++ b/src/backend/providers/SearchContext.cpp
@@ -102,7 +102,8 @@ std::vector<model::Game*> SearchContext::games_by_slug(const QString& slug) cons
 {
     std::vector<model::Game*> found_games;
     for (const auto& pair : m_game_entries) {
-        if (pair.first->slug() == slug) found_games.emplace_back(pair.first);
+        if (pair.first->slug() == slug) 
+            found_games.emplace_back(pair.first);
     }
     return found_games;
 }
@@ -258,7 +259,7 @@ void SearchContext::finalize_apply_lists()
     for (auto& pair : m_collection_games) {
         VEC_REMOVE_DUPLICATES(pair.second);
         pair.first->setGames(std::move(pair.second));
-    } 
+    }
 }
 
 std::pair<std::vector<model::Collection*>, std::vector<model::Game*>> SearchContext::finalize(QObject* const parent)

--- a/src/backend/providers/SearchContext.h
+++ b/src/backend/providers/SearchContext.h
@@ -47,6 +47,7 @@ public:
     model::Game* create_game();
     SearchContext& game_add_to(model::Game&, model::Collection&);
 
+    std::vector<model::Game*> games_by_slug(const QString&) const;
     model::Game* game_by_filepath(const QString&) const;
     model::Game* game_by_uri(const QString&) const;
     model::GameFile* gamefile_by_filepath(const QString&) const;

--- a/src/backend/providers/pegasus_metadata/PegasusMetadata.cpp
+++ b/src/backend/providers/pegasus_metadata/PegasusMetadata.cpp
@@ -82,6 +82,7 @@ enum class GameAttrib : unsigned char {
     LAUNCH_CMD,
     LAUNCH_WORKDIR,
     SORT_BY,
+    SLUG,
 };
 
 
@@ -134,6 +135,7 @@ Metadata::Metadata(QString log_tag)
         { QStringLiteral("description"), GameAttrib::LONG_DESC },
         { QStringLiteral("release"), GameAttrib::RELEASE },
         { QStringLiteral("rating"), GameAttrib::RATING },
+        { QStringLiteral("slug"), GameAttrib::SLUG },
         // sort title variations
         { QStringLiteral("sorttitle"), GameAttrib::SORT_BY },
         { QStringLiteral("sortname"), GameAttrib::SORT_BY },
@@ -425,6 +427,12 @@ void Metadata::apply_game_entry(ParserState& ps, const metafile::Entry& entry, S
             break;
         case GameAttrib::SORT_BY:
             ps.cur_game->setSortBy(first_line_of(ps, entry));
+            break;
+        case GameAttrib::SLUG:
+            // normalize slug to lowercase without spaces
+            ps.cur_game->setSlug(first_line_of(ps, entry)
+                .toLower()
+                .remove(QLatin1String(R"( )")));
             break;
     }
 }

--- a/src/backend/providers/pegasus_metadata/PegasusMetadata.cpp
+++ b/src/backend/providers/pegasus_metadata/PegasusMetadata.cpp
@@ -429,10 +429,8 @@ void Metadata::apply_game_entry(ParserState& ps, const metafile::Entry& entry, S
             ps.cur_game->setSortBy(first_line_of(ps, entry));
             break;
         case GameAttrib::SLUG:
-            // normalize slug to lowercase without spaces
-            ps.cur_game->setSlug(first_line_of(ps, entry)
-                .toLower()
-                .remove(QLatin1String(R"( )")));
+            // normalize slug to lowercase
+            ps.cur_game->setSlug(first_line_of(ps, entry).toLower());
             break;
     }
 }

--- a/src/backend/providers/pegasus_playtime/PlaytimeStats.cpp
+++ b/src/backend/providers/pegasus_playtime/PlaytimeStats.cpp
@@ -33,7 +33,7 @@
 
 
 namespace {
-const QString SLUG_PREFIX = QStringLiteral("pg-slug:");
+const QString SLUG_PREFIX = QStringLiteral("pegasus-slug:");
 QString default_db_path()
 {
     return paths::writableConfigDir() + QStringLiteral("/stats.db");
@@ -165,10 +165,11 @@ void update_modelgame(model::GameFile* const gamefile, const QDateTime& start_ti
 {
     Q_ASSERT(gamefile && gamefile->parentGame());
     model::Game* game = gamefile->parentGame();
-    if (game->hasSlug())
+    if (game->hasSlug()) {
         game->update_playstats(1, duration, start_time.addSecs(duration));
-    else
+    } else {
         gamefile->update_playstats(1, duration, start_time.addSecs(duration));
+    }
 }
 
 } // namespace
@@ -237,9 +238,6 @@ Provider& PlaytimeStats::run(SearchContext& sctx)
 
         if (path.startsWith(SLUG_PREFIX)) {
             std::vector<model::Game*> games = sctx.games_by_slug(path.mid(SLUG_PREFIX.length()));
-            if (games.empty())
-                continue;
-
             for (model::Game* game_ptr : games)
                 update_stats(stat_map_game[game_ptr]);
         } else {
@@ -250,10 +248,8 @@ Provider& PlaytimeStats::run(SearchContext& sctx)
                 if (game_ptr && game_ptr->hasUri())
                     m_pending_migrations.emplace_back(game_ptr);
             }
-            if (!game_ptr)
-                continue;
-
-            update_stats(stat_map_gamefile[game_ptr]);
+            if (game_ptr)
+                update_stats(stat_map_gamefile[game_ptr]);
         }
     }
 
@@ -333,14 +329,15 @@ void PlaytimeStats::start_processing()
 
             for (const QueueEntry& entry : m_active_tasks) {
                 const model::Game* game = entry.gamefile->parentGame();
-                const QString path = !game->hasSlug() ?
-                    // game slug overrides everything
-                    SLUG_PREFIX + game->slug()
-                    // use URI if provided
-                    : entry.gamefile->hasUri()
-                    ? entry.gamefile->uri()
-                    // otherwise use the file path
-                    : ::clean_abs_path(entry.gamefile->fileinfo());
+                // file path as default
+                QString path = ::clean_abs_path(entry.gamefile->fileinfo());
+                // game slug overrides everything
+                if (game->hasSlug())
+                    path = SLUG_PREFIX + game->slug();
+                // otherwise use URI if provided
+                else if (entry.gamefile->hasUri())
+                    path = entry.gamefile->uri();
+
                 const int path_id = get_path_id(display_name(), path);
                 if (path_id >= 0)
                     save_play_entry(display_name(), path_id, entry.launch_time, entry.duration);

--- a/src/backend/providers/pegasus_playtime/PlaytimeStats.cpp
+++ b/src/backend/providers/pegasus_playtime/PlaytimeStats.cpp
@@ -33,6 +33,7 @@
 
 
 namespace {
+const QString SLUG_PREFIX = QStringLiteral("pg-slug:");
 QString default_db_path()
 {
     return paths::writableConfigDir() + QStringLiteral("/stats.db");
@@ -162,8 +163,12 @@ void migrate_play_entry(const QString& log_tag, int old_path_id, int new_path_id
 
 void update_modelgame(model::GameFile* const gamefile, const QDateTime& start_time, const qint64 duration)
 {
-    Q_ASSERT(gamefile);
-    gamefile->update_playstats(1, duration, start_time.addSecs(duration));
+    Q_ASSERT(gamefile && gamefile->parentGame());
+    model::Game* game = gamefile->parentGame();
+    if (game->hasSlug())
+        game->update_playstats(1, duration, start_time.addSecs(duration));
+    else
+        gamefile->update_playstats(1, duration, start_time.addSecs(duration));
 }
 
 } // namespace
@@ -214,34 +219,52 @@ Provider& PlaytimeStats::run(SearchContext& sctx)
         qint64 playtime { 0 };
         QDateTime last_played;
     };
-    HashMap<model::GameFile*, Stats> stat_map;
+    HashMap<model::Game*, Stats> stat_map_game;
+    HashMap<model::GameFile*, Stats> stat_map_gamefile;
 
     QMutexLocker lock(&m_queue_guard);
 
     while (query.next()) {
         const QString path = query.value(0).toString();
-        model::GameFile* game_ptr = sctx.gamefile_by_uri(path);
-        if (!game_ptr) {
-            game_ptr = sctx.gamefile_by_filepath(path);
-            // schedule a data migration if path is being used for a URI game
-            if (game_ptr && game_ptr->hasUri())
-                m_pending_migrations.emplace_back(game_ptr);
-        }
-        if (!game_ptr)
-            continue;
-
         const qint64 start_epoch = query.value(1).toLongLong();
         const qint64 duration = query.value(2).toLongLong();
 
-        Stats& stats = stat_map[game_ptr];
-        stats.last_played = QDateTime::fromSecsSinceEpoch(start_epoch + duration);
-        stats.playtime += std::max(static_cast<qint64>(0), duration);
-        stats.playcount++;
+        const auto update_stats = [&](Stats& stats) {
+            stats.last_played = QDateTime::fromSecsSinceEpoch(start_epoch + duration);
+            stats.playtime += std::max(static_cast<qint64>(0), duration);
+            stats.playcount++;
+        };
+
+        if (path.startsWith(SLUG_PREFIX)) {
+            std::vector<model::Game*> games = sctx.games_by_slug(path.mid(SLUG_PREFIX.length()));
+            if (games.empty())
+                continue;
+
+            for (model::Game* game_ptr : games)
+                update_stats(stat_map_game[game_ptr]);
+        } else {
+            model::GameFile* game_ptr = sctx.gamefile_by_uri(path);
+            if (!game_ptr) {
+                game_ptr = sctx.gamefile_by_filepath(path);
+                // schedule a data migration if path is being used for a URI game
+                if (game_ptr && game_ptr->hasUri())
+                    m_pending_migrations.emplace_back(game_ptr);
+            }
+            if (!game_ptr)
+                continue;
+
+            update_stats(stat_map_gamefile[game_ptr]);
+        }
     }
 
     // trigger update only once
     // TODO: C++17
-    for (const auto& pair : stat_map) {
+    for (const auto& pair : stat_map_game) {
+        model::Game* const game = pair.first;
+        const Stats& stats = pair.second;
+        game->update_playstats(stats.playcount, stats.playtime, stats.last_played);
+    }
+    for (const auto& pair : stat_map_gamefile) {
         model::GameFile* const gamefile = pair.first;
         const Stats& stats = pair.second;
         gamefile->update_playstats(stats.playcount, stats.playtime, stats.last_played);
@@ -309,8 +332,14 @@ void PlaytimeStats::start_processing()
             }
 
             for (const QueueEntry& entry : m_active_tasks) {
-                const QString path = entry.gamefile->hasUri()
+                const model::Game* game = entry.gamefile->parentGame();
+                const QString path = !game->hasSlug() ?
+                    // game slug overrides everything
+                    SLUG_PREFIX + game->slug()
+                    // use URI if provided
+                    : entry.gamefile->hasUri()
                     ? entry.gamefile->uri()
+                    // otherwise use the file path
                     : ::clean_abs_path(entry.gamefile->fileinfo());
                 const int path_id = get_path_id(display_name(), path);
                 if (path_id >= 0)

--- a/tests/backend/providers/playtime/test_Playtime.cpp
+++ b/tests/backend/providers/playtime/test_Playtime.cpp
@@ -23,6 +23,7 @@
 #include "providers/pegasus_playtime/PlaytimeStats.h"
 
 #include <QSqlDatabase>
+#include <QSqlQuery>
 
 
 namespace {
@@ -50,6 +51,8 @@ private slots:
     void read();
     void write();
     void write_queue();
+    void write_slug();
+    void read_slug();
 };
 
 void test_Playtime::read()
@@ -132,6 +135,69 @@ void test_Playtime::write_queue()
     // FIXME: Flaky results on Mac
     QCOMPARE(games.at(0)->property("playCount").toInt(), 3);
 #endif
+}
+
+
+void test_Playtime::write_slug()
+{
+    QTemporaryFile db_file;
+    QVERIFY(db_file.open());
+
+    providers::SearchContext sctx;
+    model::Collection& collection = *sctx.get_or_create_collection(QStringLiteral("coll_slug"));
+    model::Game& game = *sctx.create_game_for(collection);
+    sctx.game_add_filepath(game, QStringLiteral("dummy_slug"));
+    game.setSlug(QStringLiteral("my-slug"));
+
+    providers::playtime::PlaytimeStats playtime(db_file.fileName());
+    const auto [collections, games] = sctx.finalize(this);
+
+    QSignalSpy spy_start(&playtime, &providers::playtime::PlaytimeStats::startedWriting);
+    QSignalSpy spy_end(&playtime, &providers::playtime::PlaytimeStats::finishedWriting);
+    QVERIFY(spy_start.isValid() && spy_end.isValid());
+
+    playtime.onGameLaunched(games.at(0)->filesModel()->entries().front());
+    playtime.onGameFinished(games.at(0)->filesModel()->entries().front());
+
+    QVERIFY(spy_start.count() || spy_start.wait());
+    QVERIFY(spy_end.count() || spy_end.wait());
+    QCOMPARE(spy_start.count(), 1);
+    QCOMPARE(spy_end.count(), 1);
+
+    QCOMPARE(games.at(0)->property("playCount").toInt(), 1);
+}
+
+void test_Playtime::read_slug()
+{
+    QTemporaryFile db_file;
+    QVERIFY(db_file.open());
+
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase(QStringLiteral("QSQLITE"), QStringLiteral("slug_read"));
+        db.setDatabaseName(db_file.fileName());
+        QVERIFY(db.open());
+
+        QSqlQuery query(db);
+        query.exec(QStringLiteral("CREATE TABLE paths (id INTEGER PRIMARY KEY, path TEXT UNIQUE NOT NULL);"));
+        query.exec(QStringLiteral("CREATE TABLE plays (id INTEGER PRIMARY KEY, path_id INTEGER NOT NULL REFERENCES plays(id), start_time INTEGER NOT NULL, duration INTEGER NOT NULL);"));
+        query.exec(QStringLiteral("INSERT INTO paths VALUES (1, 'pg-slug:my-slug');"));
+        query.exec(QStringLiteral("INSERT INTO plays VALUES (1, 1, 1531755000, 35);"));
+        db.close();
+    }
+    QSqlDatabase::removeDatabase(QStringLiteral("slug_read"));
+
+    providers::SearchContext sctx;
+    model::Collection& collection = *sctx.get_or_create_collection(QStringLiteral("coll_slug"));
+    model::Game& game = *sctx.create_game_for(collection);
+    sctx.game_add_filepath(game, QStringLiteral("/my/game"));
+    game.setSlug(QStringLiteral("my-slug"));
+
+    providers::playtime::PlaytimeStats(db_file.fileName()).run(sctx);
+    const auto [collections, games] = sctx.finalize(this);
+
+    QCOMPARE(games.at(0)->property("playCount").toInt(), 1);
+    QCOMPARE(games.at(0)->property("playTime").toInt(), 35);
+    QCOMPARE(games.at(0)->property("lastPlayed").toDateTime(), QDateTime::fromSecsSinceEpoch(1531755035));
 }
 
 

--- a/tests/backend/providers/playtime/test_Playtime.cpp
+++ b/tests/backend/providers/playtime/test_Playtime.cpp
@@ -180,7 +180,7 @@ void test_Playtime::read_slug()
         QSqlQuery query(db);
         query.exec(QStringLiteral("CREATE TABLE paths (id INTEGER PRIMARY KEY, path TEXT UNIQUE NOT NULL);"));
         query.exec(QStringLiteral("CREATE TABLE plays (id INTEGER PRIMARY KEY, path_id INTEGER NOT NULL REFERENCES plays(id), start_time INTEGER NOT NULL, duration INTEGER NOT NULL);"));
-        query.exec(QStringLiteral("INSERT INTO paths VALUES (1, 'pg-slug:my-slug');"));
+        query.exec(QStringLiteral("INSERT INTO paths VALUES (1, 'pegasus-slug:my-slug');"));
         query.exec(QStringLiteral("INSERT INTO plays VALUES (1, 1, 1531755000, 35);"));
         db.close();
     }


### PR DESCRIPTION
followup to #1182 without the architectural changes

adds a "slug" property to metadata files which is attached to a game
the slug is not unique, multiple games can have the same slug and they will simply share playtime
slugs are normalized to lowercase and spaces removed
if a slug is set on a game, it will be used to store plays in the database for all of the files of the game, overriding any paths/uris
existing plays using uri/path are NOT migrated to the slug pattern, they are just aggregated
also did a quick test for read/write of playtime using slugs

games have their own `play_stats_self` member which contain play stats added to that specific game independent of any files
this is summed in along with the individual game file play stats for the total playtime/stats on the game

slugs stored in the database have `pg-slug:` prepended to them to differentiate them from paths and other URIs

will follow up with a docs PR if approved

closes #1097
closes #1182 