### PR TITLE
Fix: Disable Qt Android focus highlight in CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,6 +31,16 @@ jobs:
         run: |
           .circleci/prepare.sh
           curl -L ${TOOLS_URL}/openssl-111t_android.tar.xz | tar xJf - -C /opt/
+
+      - name: Patch Qt Android focus highlight
+        run: |
+          qt_root="/opt/${QT_VERSION}_${QT_TARGET}"
+          qt_edit_text="${qt_root}/src/android/jar/src/org/qtproject/qt5/android/QtEditText.java"
+          test -f "${qt_edit_text}"
+          patch --batch --forward --strip=1 --directory="${qt_root}" \
+            < "${GITHUB_WORKSPACE}/etc/patches/qt-5.15.10-android-disable-focus-highlight.patch"
+          grep -Fq 'setDefaultFocusHighlightEnabled(false);' "${qt_edit_text}"
+
       - name: Build
         env:
           BUILDOPTS: ANDROID_ABIS=${{ matrix.abi }} FORCE_QT_PNG=1

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -40,7 +40,8 @@ jobs:
           qt_source_root="${RUNNER_TEMP}/qtbase"
           qt_package_dir="${qt_source_root}/src/android/jar/src/org/qtproject/qt5/android"
           qt_classes="${RUNNER_TEMP}/qt-android-classes"
-          android_jar="${ANDROID_HOME}/platforms/android-30/android.jar"
+          android_jar="$(find "${ANDROID_HOME}/platforms" -mindepth 2 -maxdepth 2 \
+            -name android.jar -print | sort -V | tail -n 1)"
 
           test -f "${qt_android_jar}"
           test -f "${android_jar}"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -34,12 +34,30 @@ jobs:
 
       - name: Patch Qt Android focus highlight
         run: |
+          set -euxo pipefail
           qt_root="/opt/${QT_VERSION}_${QT_TARGET}"
-          qt_edit_text="${qt_root}/src/android/jar/src/org/qtproject/qt5/android/QtEditText.java"
-          test -f "${qt_edit_text}"
-          patch --batch --forward --strip=1 --directory="${qt_root}" \
+          qt_android_jar="${qt_root}/jar/QtAndroid.jar"
+          qt_source_root="${RUNNER_TEMP}/qtbase"
+          qt_package_dir="${qt_source_root}/src/android/jar/src/org/qtproject/qt5/android"
+          qt_classes="${RUNNER_TEMP}/qt-android-classes"
+          android_jar="${ANDROID_HOME}/platforms/android-30/android.jar"
+
+          test -f "${qt_android_jar}"
+          test -f "${android_jar}"
+          mkdir -p "${qt_package_dir}" "${qt_classes}"
+          curl --fail --location --retry 3 \
+            --output "${qt_package_dir}/QtEditText.java" \
+            "https://raw.githubusercontent.com/qt/qtbase/v${QT_VERSION_PRETTY}-lts-lgpl/src/android/jar/src/org/qtproject/qt5/android/QtEditText.java"
+          patch --batch --forward --strip=1 --directory="${qt_source_root}" \
             < "${GITHUB_WORKSPACE}/etc/patches/qt-5.15.10-android-disable-focus-highlight.patch"
-          grep -Fq 'setDefaultFocusHighlightEnabled(false);' "${qt_edit_text}"
+          javac -source 8 -target 8 \
+            -classpath "${qt_android_jar}:${android_jar}" \
+            -d "${qt_classes}" \
+            "${qt_package_dir}/QtEditText.java"
+          jar --update --file "${qt_android_jar}" \
+            -C "${qt_classes}" org/qtproject/qt5/android/QtEditText.class
+          javap -classpath "${qt_android_jar}" -c org.qtproject.qt5.android.QtEditText \
+            | grep -F 'setDefaultFocusHighlightEnabled'
 
       - name: Build
         env:

--- a/etc/patches/qt-5.15.10-android-disable-focus-highlight.patch
+++ b/etc/patches/qt-5.15.10-android-disable-focus-highlight.patch
@@ -1,0 +1,13 @@
+diff --git a/src/android/jar/src/org/qtproject/qt5/android/QtEditText.java b/src/android/jar/src/org/qtproject/qt5/android/QtEditText.java
+--- a/src/android/jar/src/org/qtproject/qt5/android/QtEditText.java
++++ b/src/android/jar/src/org/qtproject/qt5/android/QtEditText.java
+@@ -83,6 +83,8 @@ public class QtEditText extends View
+     {
+         super(context);
+         setFocusable(true);
+         setFocusableInTouchMode(true);
++        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O)
++            setDefaultFocusHighlightEnabled(false);
+         m_activityDelegate = activityDelegate;
+     }
+     public QtActivityDelegate getActivityDelegate()


### PR DESCRIPTION
## Summary

Fixes a blue highlight that remains visible on the main screen after opening and closing the search/filter input on Android 8.0 and newer.
<img width="1080" height="2400" alt="7EB7A4E51AE5B301B5966D5C94F6D96D" src="https://github.com/user-attachments/assets/85e8a0f4-ce1b-49fe-9677-b25eea625b64" />
<img width="864" height="1920" alt="60FD0C07E0C30E0121A2B95BB549CAD6" src="https://github.com/user-attachments/assets/cf28e1d8-0274-4add-9683-68e5fabc8057" />

## Cause

This highlight is not rendered by the Pegasus QML theme. Qt 5.15.10 creates a transparent native `QtEditText` view to communicate with the Android input method.

When the software keyboard is shown, Qt positions this view over the QML `TextInput` and requests focus. Hiding the keyboard does not clear the native view's focus, so Android continues drawing its default focus highlight at the previous input position.

## Fix

Add a small patch for Qt's Android `QtEditText` implementation that disables the default focus highlight on API 26 and newer:

```java
if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O)
    setDefaultFocusHighlightEnabled(false);

